### PR TITLE
Add unit test for MotionPool

### DIFF
--- a/server/classes/motion_pool.cc
+++ b/server/classes/motion_pool.cc
@@ -1,6 +1,6 @@
 /* motion_pool.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 15 Nov 2015, 13:16:38 tquirk
+ *   last updated 19 Nov 2015, 17:54:15 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2015  Trinity Annabelle Quirk
@@ -58,9 +58,9 @@ void *MotionPool::motion_pool_worker(void *arg)
         zone->motion_pool->pop(&req);
 
         gettimeofday(&current, NULL);
-        interval = (current.tv_sec + (current.tv_usec * 1000000))
+        interval = (current.tv_sec + (current.tv_usec / 1000000.0))
             - (req->last_updated.tv_sec
-               + (req->last_updated.tv_usec * 1000000));
+               + (req->last_updated.tv_usec / 1000000.0));
         memcpy(&req->last_updated, &current, sizeof(struct timeval));
         zone->sector_contains(req->position)->remove(req);
         req->position += req->movement * interval;

--- a/server/classes/zone.h
+++ b/server/classes/zone.h
@@ -1,6 +1,6 @@
 /* zone.h                                                  -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 15 Nov 2015, 22:12:26 tquirk
+ *   last updated 19 Nov 2015, 07:36:01 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2015  Trinity Annabelle Quirk
@@ -116,7 +116,7 @@ class Zone
     void stop(void);
 
     /* Interface to the action pool */
-     virtual void add_action_request(uint64_t, packet *, size_t);
+    virtual void add_action_request(uint64_t, packet *, size_t);
 
     virtual void execute_action(Control *, action_request&, size_t);
 };

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -7,6 +7,7 @@ t_basesock
 t_console
 t_library
 t_log
+t_motion_pool
 t_sockaddr
 t_subserver
 t_threadpool

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -14,6 +14,7 @@ TC = t_action_pool \
 	t_console \
 	t_library \
 	t_log \
+	t_motion_pool \
 	t_sockaddr \
 	t_subserver \
 	t_threadpool \
@@ -83,6 +84,19 @@ t_library_LDADD = $(GTEST_MAIN_OBJ) $(GTEST_LIBS)
 
 t_log_SOURCES = t_log.cc ../server/log.cc ../server/log.h
 t_log_LDADD = $(GTEST_LIBS)
+
+t_motion_pool_SOURCES = t_motion_pool.cc \
+	../server/classes/action_pool.cc ../server/classes/action_pool.h \
+	../server/classes/motion_pool.cc ../server/classes/motion_pool.h \
+	../server/classes/update_pool.cc ../server/classes/update_pool.h \
+	../server/classes/zone.cc ../server/classes/zone.h \
+	../server/classes/game_obj.cc ../server/classes/game_obj.h \
+	../server/classes/library.cc ../server/classes/library.h \
+	../server/classes/octree.cc ../server/classes/octree.h \
+	../server/log.cc ../server/log.h \
+	../server/config_data.cc ../server/config_data.h
+t_motion_pool_CXXFLAGS = $(CONFIG_DEFS) $(GTEST_INCLUDES)
+t_motion_pool_LDADD = $(GTEST_MAIN_OBJ) $(GTEST_LIBS) ../proto/libr9_proto.la
 
 t_sockaddr_SOURCES = t_sockaddr.cc ../server/classes/sockaddr.h
 t_sockaddr_LDADD = $(GTEST_MAIN_OBJ) $(GTEST_LIBS)

--- a/test/t_motion_pool.cc
+++ b/test/t_motion_pool.cc
@@ -1,0 +1,35 @@
+#include "../server/classes/motion_pool.h"
+#include "../server/classes/zone.h"
+#include "../server/classes/game_obj.h"
+#include "../server/classes/modules/db.h"
+
+#include <gtest/gtest.h>
+
+std::vector<listen_socket *> sockets;
+DB *database;
+
+TEST(MotionPoolTest, Operate)
+{
+    Zone *zone = new Zone(1000LL, 1);
+    MotionPool *pool = new MotionPool("t_motion", 1);
+    GameObject *go = new GameObject(NULL, NULL, 9876LL);
+
+    go->position = { 234.0, 234.0, 234.0 };
+    go->movement = { 1.0, 1.0, 1.0 };
+    gettimeofday(&go->last_updated, NULL);
+    pool->push(go);
+    ASSERT_EQ(pool->queue_size(), 1);
+
+    delete zone->motion_pool;
+    zone->motion_pool = pool;
+    zone->motion_pool->startup_arg = (void *)zone;
+    zone->motion_pool->start(MotionPool::motion_pool_worker);
+    sleep(1);
+    zone->motion_pool->stop();
+
+    ASSERT_GT(go->position.x(), 234.0);
+    ASSERT_GT(go->position.y(), 234.0);
+    ASSERT_GT(go->position.z(), 234.0);
+
+    delete zone;
+}


### PR DESCRIPTION
The MotionPool was both simpler and trickier to test.  GMock wasn't
playing nice, so I couldn't verify that the game object was being
pushed back onto the pool.  I decided to simply let the pool run
for one second, and verify that the object's position was changed.

Re: issue #14