### PR TITLE
Improve test coverage

### DIFF
--- a/server/classes/game_obj.cc
+++ b/server/classes/game_obj.cc
@@ -78,7 +78,11 @@ GameObject::~GameObject()
 
 GameObject *GameObject::clone(void) const
 {
-    return new GameObject(default_geometry, default_master);
+    /* Each object completely owns its geometry, so we need to make a
+     * new copy for the new object.
+     */
+    Geometry *new_geom = new Geometry(*this->default_geometry);
+    return new GameObject(new_geom, this->default_master);
 }
 
 uint64_t GameObject::get_object_id(void) const

--- a/server/classes/game_obj.cc
+++ b/server/classes/game_obj.cc
@@ -1,6 +1,6 @@
 /* game_obj.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 10 Jul 2016, 10:10:50 tquirk
+ *   last updated 02 Jun 2017, 09:16:54 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2016  Trinity Annabelle Quirk
@@ -56,16 +56,14 @@ GameObject::GameObject(Geometry *g, Control *c, uint64_t newid)
     this->default_geometry = this->geometry = g;
     pthread_mutex_lock(&GameObject::max_mutex);
     if (newid == 0LL)
-    {
         newid = GameObject::max_id_value++;
-    }
     else
-    {
         /* This clause is mostly for recreating an object from some
          * saved state.
          */
-        GameObject::max_id_value = std::max(GameObject::max_id_value, newid);
-    }
+        GameObject::max_id_value = std::max(GameObject::max_id_value,
+                                            newid + 1);
+
     pthread_mutex_unlock(&GameObject::max_mutex);
     this->id_value = newid;
 }

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -9,6 +9,7 @@ t_comm_exception
 t_configdata
 t_console
 t_font
+t_game_obj
 t_image
 t_library
 t_log

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -9,6 +9,7 @@ t_comm_exception
 t_configdata
 t_console
 t_font
+t_image
 t_library
 t_log
 t_logbuf

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -33,7 +33,8 @@ if WANT_CLIENT
 	t_comm \
 	t_comm_exception \
 	t_configdata \
-	t_font
+	t_font \
+	t_image
 endif
 
 TESTS = $(TC)
@@ -171,6 +172,9 @@ t_font_CXXFLAGS = $(CLIENT_CXXFLAGS) $(CLIENT_INCLUDES) \
 	-DSTORE_PREFIX=\"../client\"
 t_font_LDADD = $(GTEST_MAIN_OBJ) $(GTEST_LIBS) \
 	$(XERCES_LDLIBS) $(FREETYPE_LDLIBS)
+
+t_image_SOURCES = t_image.cc ../client/ui/image.h
+t_image_LDADD = $(GTEST_MAIN_OBJ) $(GTEST_LIBS)
 
 clean-local:
 	rm -f *.gcno *.gcda *.gcov

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -14,6 +14,7 @@ if WANT_SERVER
   TC += t_action_pool \
 	t_basesock \
 	t_console \
+	t_game_obj \
 	t_library \
 	t_log \
 	t_motion_pool \
@@ -86,6 +87,12 @@ t_console_SOURCES = t_console.cc \
 	../server/config_data.cc ../server/config_data.h
 t_console_CXXFLAGS = $(CONFIG_DEFS) $(GMOCK_INCLUDES) $(GTEST_INCLUDES)
 t_console_LDADD = $(GTEST_MAIN_OBJ) $(GTEST_LIBS) $(WRAP_LDLIBS)
+
+t_game_obj_SOURCES = t_game_obj.cc \
+	../server/classes/game_obj.cc ../server/classes/game_obj.h \
+	../server/classes/control.cc ../server/classes/control.h \
+	../server/classes/geometry.cc ../server/classes/geometry.h
+t_game_obj_LDADD = $(GTEST_MAIN_OBJ) $(GTEST_LIBS)
 
 t_library_SOURCES = t_library.cc \
 	../server/classes/library.cc ../server/classes/library.h

--- a/test/t_game_obj.cc
+++ b/test/t_game_obj.cc
@@ -66,3 +66,40 @@ TEST(GameObjTest, Clone)
     delete go2;
     delete con;
 }
+
+TEST(GameObjTest, ConnectDisconnect)
+{
+    GameObject *go = NULL;
+    Geometry *geom = new Geometry();
+    Control *con = new Control(1LL, NULL);
+
+    lock_count = unlock_count = 0;
+    go = new GameObject(geom, con, 45LL);
+    ASSERT_EQ(go->get_object_id(), 45LL);
+    ASSERT_TRUE(go->master == con);
+    ASSERT_TRUE(go->geometry == geom);
+    ASSERT_EQ(lock_count, unlock_count);
+
+    Control *con2 = new Control(2LL, NULL);
+
+    ASSERT_TRUE(go->connect(con2));
+    ASSERT_TRUE(go->master == con2);
+
+    Control *con3 = new Control(3LL, NULL);
+
+    ASSERT_FALSE(go->connect(con3));
+    ASSERT_TRUE(go->master == con2);
+
+    delete con3;
+
+    /* Disconnect something that's not the current master, should be no-op. */
+    go->disconnect(con);
+    ASSERT_TRUE(go->master == con2);
+
+    go->disconnect(con2);
+    ASSERT_TRUE(go->master == con);
+
+    delete con2;
+    delete go;
+    delete con;
+}

--- a/test/t_game_obj.cc
+++ b/test/t_game_obj.cc
@@ -1,0 +1,45 @@
+#include "../server/classes/game_obj.h"
+
+#include <gtest/gtest.h>
+
+bool pthread_mutex_lock_error = false, pthread_mutex_unlock_error = false;
+int lock_count, unlock_count;
+
+int pthread_mutex_lock(pthread_mutex_t *a)
+{
+    ++lock_count;
+    if (pthread_mutex_lock_error == true)
+        return EINVAL;
+    return 0;
+}
+
+int pthread_mutex_unlock(pthread_mutex_t *a)
+{
+    ++unlock_count;
+    if (pthread_mutex_unlock_error == true)
+        return EINVAL;
+    return 0;
+}
+
+TEST(GameObjTest, CreateDelete)
+{
+    GameObject *go = NULL;
+    Geometry *geom = new Geometry();
+    Control *con = new Control(1LL, NULL);
+
+    lock_count = unlock_count = 0;
+    go = new GameObject(geom, con, 38LL);
+    ASSERT_EQ(go->get_object_id(), 38LL);
+    ASSERT_TRUE(go->master == con);
+    ASSERT_TRUE(go->geometry == geom);
+    ASSERT_EQ(lock_count, unlock_count);
+
+    delete go;
+
+    geom = new Geometry();
+    go = new GameObject(geom, con);
+    ASSERT_EQ(go->get_object_id(), 39LL);
+
+    delete go;
+    delete con;
+}

--- a/test/t_game_obj.cc
+++ b/test/t_game_obj.cc
@@ -24,7 +24,7 @@ int pthread_mutex_unlock(pthread_mutex_t *a)
 TEST(GameObjTest, CreateDelete)
 {
     GameObject *go = NULL;
-    Geometry *geom = new Geometry();
+    Geometry *geom = new Geometry(), *geom2 = new Geometry();
     Control *con = new Control(1LL, NULL);
 
     lock_count = unlock_count = 0;
@@ -39,6 +39,7 @@ TEST(GameObjTest, CreateDelete)
 
     geom = new Geometry();
     go = new GameObject(geom, con);
+    go->geometry = geom2;
     ASSERT_EQ(go->get_object_id(), 39LL);
 
     delete go;

--- a/test/t_game_obj.cc
+++ b/test/t_game_obj.cc
@@ -103,3 +103,34 @@ TEST(GameObjTest, ConnectDisconnect)
     delete go;
     delete con;
 }
+
+TEST(GameObjTest, ResetId)
+{
+    GameObject *go = NULL;
+    Geometry *geom = new Geometry();
+    Control *con = new Control(1LL, NULL);
+
+    lock_count = unlock_count = 0;
+    go = new GameObject(geom, con, 123LL);
+    ASSERT_EQ(go->get_object_id(), 123LL);
+    ASSERT_TRUE(go->master == con);
+    ASSERT_TRUE(go->geometry == geom);
+    ASSERT_EQ(lock_count, unlock_count);
+
+    delete go;
+
+    geom = new Geometry();
+    go = new GameObject(geom, con);
+    ASSERT_EQ(go->get_object_id(), 124LL);
+
+    delete go;
+
+    GameObject::reset_max_id();
+
+    geom = new Geometry();
+    go = new GameObject(geom, con);
+    ASSERT_EQ(go->get_object_id(), 0LL);
+
+    delete go;
+    delete con;
+}

--- a/test/t_game_obj.cc
+++ b/test/t_game_obj.cc
@@ -141,3 +141,25 @@ TEST(GameObjTest, ResetId)
     delete go;
     delete con;
 }
+
+TEST(GameObjTest, Distance)
+{
+    GameObject *go = NULL;
+    Geometry *geom = new Geometry();
+    Control *con = new Control(1LL, NULL);
+
+    lock_count = unlock_count = 0;
+    go = new GameObject(geom, con, 123LL);
+    ASSERT_EQ(go->get_object_id(), 123LL);
+    ASSERT_TRUE(go->master == con);
+    ASSERT_TRUE(go->geometry == geom);
+    ASSERT_EQ(lock_count, unlock_count);
+    ASSERT_GT(lock_count, 0);
+
+    glm::dvec3 pt = {0.0, 0.0, 0.0};
+    go->position.x = 1.0;
+    ASSERT_EQ(go->distance_from(pt), 1.0);
+
+    delete go;
+    delete con;
+}

--- a/test/t_game_obj.cc
+++ b/test/t_game_obj.cc
@@ -33,6 +33,7 @@ TEST(GameObjTest, CreateDelete)
     ASSERT_TRUE(go->master == con);
     ASSERT_TRUE(go->geometry == geom);
     ASSERT_EQ(lock_count, unlock_count);
+    ASSERT_GT(lock_count, 0);
 
     delete go;
 
@@ -56,6 +57,7 @@ TEST(GameObjTest, Clone)
     ASSERT_TRUE(go->master == con);
     ASSERT_TRUE(go->geometry == geom);
     ASSERT_EQ(lock_count, unlock_count);
+    ASSERT_GT(lock_count, 0);
 
     GameObject *go2 = go->clone();
     ASSERT_EQ(go2->get_object_id(), 46LL);
@@ -79,6 +81,7 @@ TEST(GameObjTest, ConnectDisconnect)
     ASSERT_TRUE(go->master == con);
     ASSERT_TRUE(go->geometry == geom);
     ASSERT_EQ(lock_count, unlock_count);
+    ASSERT_GT(lock_count, 0);
 
     Control *con2 = new Control(2LL, NULL);
 
@@ -116,6 +119,7 @@ TEST(GameObjTest, ResetId)
     ASSERT_TRUE(go->master == con);
     ASSERT_TRUE(go->geometry == geom);
     ASSERT_EQ(lock_count, unlock_count);
+    ASSERT_GT(lock_count, 0);
 
     delete go;
 
@@ -125,7 +129,10 @@ TEST(GameObjTest, ResetId)
 
     delete go;
 
+    lock_count = unlock_count = 0;
     GameObject::reset_max_id();
+    ASSERT_EQ(lock_count, unlock_count);
+    ASSERT_GT(lock_count, 0);
 
     geom = new Geometry();
     go = new GameObject(geom, con);

--- a/test/t_game_obj.cc
+++ b/test/t_game_obj.cc
@@ -43,3 +43,26 @@ TEST(GameObjTest, CreateDelete)
     delete go;
     delete con;
 }
+
+TEST(GameObjTest, Clone)
+{
+    GameObject *go = NULL;
+    Geometry *geom = new Geometry();
+    Control *con = new Control(1LL, NULL);
+
+    lock_count = unlock_count = 0;
+    go = new GameObject(geom, con, 45LL);
+    ASSERT_EQ(go->get_object_id(), 45LL);
+    ASSERT_TRUE(go->master == con);
+    ASSERT_TRUE(go->geometry == geom);
+    ASSERT_EQ(lock_count, unlock_count);
+
+    GameObject *go2 = go->clone();
+    ASSERT_EQ(go2->get_object_id(), 46LL);
+    ASSERT_TRUE(go2->master == con);
+    ASSERT_TRUE(go2->geometry != geom);
+
+    delete go;
+    delete go2;
+    delete con;
+}

--- a/test/t_image.cc
+++ b/test/t_image.cc
@@ -1,0 +1,65 @@
+#include <gtest/gtest.h>
+
+#include "../client/ui/image.h"
+
+TEST(ImageTest, CreateDelete)
+{
+    ui::image *img = new ui::image();
+    ASSERT_EQ(img->width, 0);
+    ASSERT_EQ(img->height, 0);
+    ASSERT_EQ(img->per_pixel, 0);
+    ASSERT_TRUE(img->data == NULL);
+    delete img;
+}
+
+TEST(ImageTest, CopyConstructor)
+{
+    ui::image *img = new ui::image();
+    img->width = 10;
+    img->height = 10;
+    img->per_pixel = 1;
+    img->data = new unsigned char[img->width * img->height * img->per_pixel];
+
+    ui::image *new_img = new ui::image(*img);
+    ASSERT_EQ(new_img->width, 10);
+    ASSERT_EQ(new_img->height, 10);
+    ASSERT_EQ(new_img->per_pixel, 1);
+    ASSERT_TRUE(img->data != NULL);
+    delete new_img;
+    delete img;
+}
+
+TEST(ImageTest, Assignment)
+{
+    ui::image *img = new ui::image();
+    img->width = 10;
+    img->height = 10;
+    img->per_pixel = 1;
+    img->data = new unsigned char[img->width * img->height * img->per_pixel];
+
+    ui::image *new_img = new ui::image();
+
+    *new_img = *img;
+
+    ASSERT_EQ(new_img->width, 10);
+    ASSERT_EQ(new_img->height, 10);
+    ASSERT_EQ(new_img->per_pixel, 1);
+    ASSERT_TRUE(img->data != NULL);
+    delete new_img;
+    delete img;
+}
+
+TEST(ImageTest, Reset)
+{
+    ui::image *img = new ui::image();
+    img->width = 10;
+    img->height = 10;
+    img->per_pixel = 1;
+    img->data = new unsigned char[img->width * img->height * img->per_pixel];
+    img->reset();
+    ASSERT_EQ(img->width, 0);
+    ASSERT_EQ(img->height, 0);
+    ASSERT_EQ(img->per_pixel, 0);
+    ASSERT_TRUE(img->data == NULL);
+    delete img;
+}

--- a/test/t_image.cc
+++ b/test/t_image.cc
@@ -38,6 +38,12 @@ TEST(ImageTest, Assignment)
     img->data = new unsigned char[img->width * img->height * img->per_pixel];
 
     ui::image *new_img = new ui::image();
+    new_img->width = 5;
+    new_img->height = 5;
+    new_img->per_pixel = 1;
+    new_img->data = new unsigned char[new_img->width
+                                      * new_img->height
+                                      * new_img->per_pixel];
 
     *new_img = *img;
 

--- a/test/t_motion_pool.cc
+++ b/test/t_motion_pool.cc
@@ -12,13 +12,25 @@ TEST(MotionPoolTest, Operate)
 {
     Zone *zone = new Zone(1000LL, 1);
     MotionPool *pool = new MotionPool("t_motion", 1);
-    GameObject *go = new GameObject(NULL, NULL, 9876LL);
+    GameObject *go1 = new GameObject(NULL, NULL, 9876LL);
+    GameObject *go2 = new GameObject(NULL, NULL, 9877LL);
+    GameObject *go3 = new GameObject(NULL, NULL, 9878LL);
 
-    go->position = { 234.0, 234.0, 234.0 };
-    go->movement = { 1.0, 1.0, 1.0 };
-    gettimeofday(&go->last_updated, NULL);
-    pool->push(go);
+    go1->position = { 234.0, 234.0, 234.0 };
+    go1->movement = { 1.0, 1.0, 1.0 };
+    gettimeofday(&go1->last_updated, NULL);
+    pool->push(go1);
     ASSERT_EQ(pool->queue_size(), 1);
+    go2->position = { 123.0, 123.0, 123.0 };
+    go2->movement = { 0.0, 1.0, 1.0 };
+    gettimeofday(&go2->last_updated, NULL);
+    pool->push(go2);
+    ASSERT_EQ(pool->queue_size(), 2);
+    go3->position = { 12.0, 12.0, 12.0 };
+    go3->movement = { 0.0, 0.0, 1.0 };
+    gettimeofday(&go3->last_updated, NULL);
+    pool->push(go3);
+    ASSERT_EQ(pool->queue_size(), 3);
 
     delete zone->motion_pool;
     zone->motion_pool = pool;
@@ -27,9 +39,12 @@ TEST(MotionPoolTest, Operate)
     sleep(1);
     zone->motion_pool->stop();
 
-    ASSERT_GT(go->position.x, 234.0);
-    ASSERT_GT(go->position.y, 234.0);
-    ASSERT_GT(go->position.z, 234.0);
+    ASSERT_GT(go1->position.x, 234.0);
+    ASSERT_GT(go1->position.y, 234.0);
+    ASSERT_GT(go1->position.z, 234.0);
+    ASSERT_GT(go2->position.y, 123.0);
+    ASSERT_GT(go2->position.z, 123.0);
+    ASSERT_GT(go3->position.z, 12.0);
 
     delete zone;
 }

--- a/test/t_subserver.cc
+++ b/test/t_subserver.cc
@@ -51,7 +51,7 @@ class SubserverTest : public ::testing::Test
                     if (i != STDIN_FILENO)
                         close(i);
 
-                ret = execl(SUBSERVER, (char *)NULL);
+                ret = execl(SUBSERVER, "r9subserver", (char *)NULL);
 
                 /* If this returns, go ahead and blow up */
                 ASSERT_EQ(ret, 0);


### PR DESCRIPTION
Our test coverage was terrible, and after these changes, it's now just pretty lame.  The UI image type and the server GameObject are now at 100%.  The server motion_pool coverage is at its maximum, since the remaining lines are untestable at the moment (they depend on rotation, and we haven't really implemented that handling yet).