### PR TITLE
Improve test coverage

### DIFF
--- a/server/classes/dgram.cc
+++ b/server/classes/dgram.cc
@@ -1,6 +1,6 @@
 /* dgram.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 09:15:15 tquirk
+ *   last updated 18 Jul 2017, 09:31:48 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -58,8 +58,8 @@ const dgram_user& dgram_user::operator=(const dgram_user& du)
     return *this;
 }
 
-dgram_socket::dgram_socket(struct addrinfo *ai)
-    : listen_socket(ai)
+dgram_socket::dgram_socket(struct addrinfo *ai, int rt, int pt, int ldt)
+    : listen_socket(ai, rt, pt, ldt)
 {
 }
 

--- a/server/classes/dgram.cc
+++ b/server/classes/dgram.cc
@@ -77,31 +77,13 @@ std::string dgram_socket::port_type(void)
 
 void dgram_socket::start(void)
 {
-    int retval;
-
-    std::clog << "starting connection loop for datagram port "
-              << this->sock.sa->port() << std::endl;
+    this->listen_socket::start();
 
     /* Start up the listen thread and thread pools */
-    sleep(0);
     this->send_pool->startup_arg = (void *)this;
     this->send_pool->start(dgram_socket::dgram_send_worker);
-    this->access_pool->startup_arg = (void *)this;
-    this->access_pool->start(listen_socket::access_pool_worker);
     this->sock.listen_arg = (void *)this;
     this->sock.start(dgram_socket::dgram_listen_worker);
-
-    /* Start up the reaping thread */
-    if ((retval = pthread_create(&this->reaper, NULL,
-                                 dgram_reaper_worker, (void *)this)) != 0)
-    {
-        std::ostringstream s;
-        s << "couldn't create reaper thread for datagram port "
-          << this->sock.sa->port() << ": "
-          << strerror(retval) << " (" << retval << ")";
-        throw std::runtime_error(s.str());
-    }
-    this->reaper_running = true;
 }
 
 void dgram_socket::do_login(uint64_t userid,

--- a/server/classes/dgram.cc
+++ b/server/classes/dgram.cc
@@ -1,6 +1,6 @@
 /* dgram.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 09:31:48 tquirk
+ *   last updated 18 Jul 2017, 09:15:15 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -58,8 +58,8 @@ const dgram_user& dgram_user::operator=(const dgram_user& du)
     return *this;
 }
 
-dgram_socket::dgram_socket(struct addrinfo *ai, int rt, int pt, int ldt)
-    : listen_socket(ai, rt, pt, ldt)
+dgram_socket::dgram_socket(struct addrinfo *ai)
+    : listen_socket(ai)
 {
 }
 

--- a/server/classes/dgram.cc
+++ b/server/classes/dgram.cc
@@ -1,6 +1,6 @@
 /* dgram.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 06 Jul 2017, 09:53:34 tquirk
+ *   last updated 17 Jul 2017, 22:33:02 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -250,16 +250,7 @@ void *dgram_socket::dgram_reaper_worker(void *arg)
             }
             else if (dgu->timestamp < now - listen_socket::PING_TIMEOUT
                      && dgu->pending_logout == false)
-            {
-                packet_list pkt;
-
-                pkt.buf.basic.type = TYPE_PNGPKT;
-                pkt.buf.basic.version = 1;
-                pkt.buf.basic.sequence = dgu->sequence++;
-                pkt.who = dgu->control;
-                pkt.parent = dgs;
-                dgs->send_pool->push(pkt);
-            }
+                dgs->send_ping(dgu->control);
         }
         pthread_testcancel();
     }

--- a/server/classes/dgram.cc
+++ b/server/classes/dgram.cc
@@ -1,6 +1,6 @@
 /* dgram.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 08:23:29 tquirk
+ *   last updated 18 Jul 2017, 09:15:15 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -107,7 +107,7 @@ void dgram_socket::do_logout(base_user *bu)
     dgram_user *dgu = dynamic_cast<dgram_user *>(bu);
 
     if (dgu != NULL)
-        dgs->socks.erase(dgu->sa);
+        this->socks.erase(dgu->sa);
 }
 
 void *dgram_socket::dgram_listen_worker(void *arg)

--- a/server/classes/dgram.cc
+++ b/server/classes/dgram.cc
@@ -1,6 +1,6 @@
 /* dgram.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 07:56:49 tquirk
+ *   last updated 18 Jul 2017, 08:23:29 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -114,6 +114,18 @@ void dgram_socket::do_login(uint64_t userid,
     this->socks[dgu->sa] = dgu;
 
     this->connect_user((base_user *)dgu, al);
+}
+
+/* The do_logout method performs the only dgram_socket-specific work
+ * for removing a datagram user from the object.  Everything else is
+ * handled in listen_socket::reaper_worker.
+ */
+void dgram_socket::do_logout(base_user *bu)
+{
+    dgram_user *dgu = dynamic_cast<dgram_user *>(bu);
+
+    if (dgu != NULL)
+        dgs->socks.erase(dgu->sa);
 }
 
 void *dgram_socket::dgram_listen_worker(void *arg)

--- a/server/classes/dgram.cc
+++ b/server/classes/dgram.cc
@@ -1,6 +1,6 @@
 /* dgram.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 17 Jul 2017, 22:33:02 tquirk
+ *   last updated 18 Jul 2017, 07:56:49 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -68,6 +68,11 @@ dgram_socket::~dgram_socket()
     /* Should we send logout messages to everybody? */
 
     /* Thread pools are handled by the listen_socket destructor */
+}
+
+std::string dgram_socket::port_type(void)
+{
+    return "datagram";
 }
 
 void dgram_socket::start(void)

--- a/server/classes/dgram.h
+++ b/server/classes/dgram.h
@@ -85,7 +85,6 @@ class dgram_socket : public listen_socket
     void do_logout(base_user *) override;
 
     static void *dgram_listen_worker(void *);
-    static void *dgram_reaper_worker(void *);
     static void *dgram_send_worker(void *);
 };
 

--- a/server/classes/dgram.h
+++ b/server/classes/dgram.h
@@ -1,6 +1,6 @@
 /* dgram.h                                                 -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 06 Jul 2017, 09:59:57 tquirk
+ *   last updated 18 Jul 2017, 07:33:12 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -76,6 +76,8 @@ class dgram_socket : public listen_socket
   public:
     dgram_socket(struct addrinfo *);
     ~dgram_socket();
+
+    std::string port_type(void) override;
 
     void start(void) override;
 

--- a/server/classes/dgram.h
+++ b/server/classes/dgram.h
@@ -82,6 +82,7 @@ class dgram_socket : public listen_socket
     void start(void) override;
 
     void do_login(uint64_t, Control *, access_list&) override;
+    void do_logout(base_user *) override;
 
     static void *dgram_listen_worker(void *);
     static void *dgram_reaper_worker(void *);

--- a/server/classes/dgram.h
+++ b/server/classes/dgram.h
@@ -1,6 +1,6 @@
 /* dgram.h                                                 -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 07:33:12 tquirk
+ *   last updated 18 Jul 2017, 09:31:07 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -74,7 +74,10 @@ class dgram_socket : public listen_socket
                      less_sockaddr>::iterator socks_iterator;
 
   public:
-    dgram_socket(struct addrinfo *);
+    dgram_socket(struct addrinfo *,
+                 int = listen_socket::REAP_TIMEOUT,
+                 int = listen_socket::PING_TIMEOUT,
+                 int = listen_socket::LINK_DEAD_TIMEOUT);
     ~dgram_socket();
 
     std::string port_type(void) override;

--- a/server/classes/dgram.h
+++ b/server/classes/dgram.h
@@ -1,6 +1,6 @@
 /* dgram.h                                                 -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 09:31:07 tquirk
+ *   last updated 18 Jul 2017, 07:33:12 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -74,10 +74,7 @@ class dgram_socket : public listen_socket
                      less_sockaddr>::iterator socks_iterator;
 
   public:
-    dgram_socket(struct addrinfo *,
-                 int = listen_socket::REAP_TIMEOUT,
-                 int = listen_socket::PING_TIMEOUT,
-                 int = listen_socket::LINK_DEAD_TIMEOUT);
+    dgram_socket(struct addrinfo *);
     ~dgram_socket();
 
     std::string port_type(void) override;

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -96,9 +96,6 @@ listen_socket::~listen_socket()
     delete this->send_pool;
     delete this->access_pool;
 
-    /* Clear out the users map */
-    for (i = this->users.begin(); i != this->users.end(); ++i)
-        delete (*i).second;
     this->users.erase(this->users.begin(), this->users.end());
 }
 

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -1,6 +1,6 @@
 /* listensock.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 23:09:24 tquirk
+ *   last updated 19 Jul 2017, 12:54:48 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -81,7 +81,12 @@ listen_socket::listen_socket(struct addrinfo *ai, int rt, int pt, int ldt)
     this->reap_time = rt;
     this->ping_time = pt;
     this->link_dead_time = ldt;
-    this->init();
+    this->send_pool = new ThreadPool<packet_list>("send", config.send_threads);
+    this->access_pool = new ThreadPool<access_list>("access",
+                                                    config.access_threads);
+    this->access_pool->clean_on_pop = true;
+
+    this->reaper_running = false;
 }
 
 listen_socket::~listen_socket()
@@ -101,16 +106,6 @@ listen_socket::~listen_socket()
 
     if (this->access_pool != NULL)
         delete this->access_pool;
-}
-
-void listen_socket::init(void)
-{
-    this->send_pool = new ThreadPool<packet_list>("send", config.send_threads);
-    this->access_pool = new ThreadPool<access_list>("access",
-                                                    config.access_threads);
-    this->access_pool->clean_on_pop = true;
-
-    this->reaper_running = false;
 }
 
 void listen_socket::start(void)

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -1,6 +1,6 @@
 /* listensock.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 19 Jul 2017, 22:26:25 tquirk
+ *   last updated 20 Jul 2017, 08:05:07 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -167,7 +167,8 @@ void *listen_socket::access_pool_worker(void *arg)
     listen_socket *ls = (listen_socket *)arg;
     access_list req;
 
-    std::clog << "started access pool worker";
+    std::clog << "started access pool worker for " << ls->port_type()
+              << " port " << ls->sock.sa->port() << std::endl;
     for (;;)
     {
         ls->access_pool->pop(&req);
@@ -180,7 +181,6 @@ void *listen_socket::access_pool_worker(void *arg)
             ls->logout_user(req);
         /* Otherwise, we don't recognize it, and will ignore it */
     }
-    std::clog << "access pool worker ending";
     return NULL;
 }
 
@@ -191,8 +191,8 @@ void *listen_socket::reaper_worker(void *arg)
     base_user *bu;
     time_t now;
 
-    std::clog << "started reaper thread for " << ls->port_type() << " port "
-              << ls->sock.sa->port() << std::endl;
+    std::clog << "started reaper thread for " << ls->port_type()
+              << " port " << ls->sock.sa->port() << std::endl;
     for (;;)
     {
         sleep(ls->reap_time);

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -1,6 +1,6 @@
 /* listensock.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 20 Jul 2017, 08:12:25 tquirk
+ *   last updated 21 Jul 2017, 08:43:01 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -197,6 +197,7 @@ void *listen_socket::reaper_worker(void *arg)
         for (i = ls->users.begin(); i != ls->users.end(); ++i)
         {
             pthread_testcancel();
+            bu = (*i).second;
             if (bu->timestamp < now - listen_socket::LINK_DEAD_TIMEOUT)
             {
                 /* We'll consider the user link-dead */
@@ -212,7 +213,14 @@ void *listen_socket::reaper_worker(void *arg)
                 }
                 delete bu->control;
                 ls->do_logout(bu);
-                ls->users.erase((*(i--)).second->userid);
+
+                /* i will be invalidated by the following erase, so
+                 * let's move to a valid spot that will let our loop
+                 * continue without missing anything.
+                 */
+                --i;
+
+                ls->users.erase(bu->userid);
             }
             else if (bu->timestamp < now - listen_socket::PING_TIMEOUT
                      && bu->pending_logout == false)

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -1,6 +1,6 @@
 /* listensock.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 09:11:52 tquirk
+ *   last updated 18 Jul 2017, 09:13:33 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -189,7 +189,7 @@ void *listen_socket::reaper_worker(void *arg)
 {
     listen_socket *ls = (listen_socket *)arg;
     listen_socket::users_iterator i;
-    bu *bu;
+    base_user *bu;
     time_t now;
 
     std::clog << "started reaper thread for " << ls->port_type() << " port "

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -1,6 +1,6 @@
 /* listensock.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 08:35:50 tquirk
+ *   last updated 18 Jul 2017, 09:11:52 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -83,7 +83,6 @@ listen_socket::listen_socket(struct addrinfo *ai)
 
 listen_socket::~listen_socket()
 {
-    int retval;
     listen_socket::users_iterator i;
 
     try { this->stop(); }
@@ -139,6 +138,8 @@ void listen_socket::start(void)
 
 void listen_socket::stop(void)
 {
+    int retval;
+
     this->send_pool->stop();
     this->access_pool->stop();
     this->sock.stop();

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -138,10 +138,6 @@ void listen_socket::stop(void)
 {
     int retval;
 
-    this->send_pool->stop();
-    this->access_pool->stop();
-    this->sock.stop();
-
     if (this->reaper_running)
     {
         if ((retval = pthread_cancel(this->reaper)) != 0)
@@ -163,6 +159,10 @@ void listen_socket::stop(void)
         }
         this->reaper_running = false;
     }
+
+    this->send_pool->stop();
+    this->access_pool->stop();
+    this->sock.stop();
 }
 
 void *listen_socket::access_pool_worker(void *arg)

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -1,6 +1,6 @@
 /* listensock.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 19 Jul 2017, 12:54:48 tquirk
+ *   last updated 19 Jul 2017, 22:26:25 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -96,16 +96,13 @@ listen_socket::~listen_socket()
     try { this->stop(); }
     catch (std::exception& e) { /* Do nothing */ }
 
+    delete this->send_pool;
+    delete this->access_pool;
+
     /* Clear out the users map */
     for (i = this->users.begin(); i != this->users.end(); ++i)
         delete (*i).second;
     this->users.erase(this->users.begin(), this->users.end());
-
-    if (this->send_pool != NULL)
-        delete this->send_pool;
-
-    if (this->access_pool != NULL)
-        delete this->access_pool;
 }
 
 void listen_socket::start(void)

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -1,6 +1,6 @@
 /* listensock.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 09:29:51 tquirk
+ *   last updated 18 Jul 2017, 23:09:24 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -151,18 +151,22 @@ void listen_socket::stop(void)
     {
         if ((retval = pthread_cancel(this->reaper)) != 0)
         {
-            std::clog << syslogErr << "couldn't cancel reaper thread for "
-                      << this->port_type() << " port "
-                      << this->sock.sa->port() << ": "
-                      << strerror(retval) << " (" << retval << ")" << std::endl;
+            std::ostringstream s;
+            s << "couldn't cancel reaper thread for " << this->port_type()
+              << " port " << this->sock.sa->port() << ": "
+              << strerror(retval) << " (" << retval << ")";
+            throw std::runtime_error(s.str());
         }
         sleep(0);
         if ((retval = pthread_join(this->reaper, NULL)) != 0)
-            std::clog << syslogErr
-                      << "error terminating reaper thread for "
-                      << this->port_type() << " port "
-                      << this->sock.sa->port() << ": "
-                      << strerror(retval) << " (" << retval << ")" << std::endl;
+        {
+            std::ostringstream s;
+            s << "couldn't join reaper thread for " << this->port_type()
+              << " port " << this->sock.sa->port() << ": "
+              << strerror(retval) << " (" << retval << ")";
+            throw std::runtime_error(s.str());
+        }
+        this->reaper_running = false;
     }
 }
 

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -1,6 +1,6 @@
 /* listensock.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 06 Jul 2017, 09:59:07 tquirk
+ *   last updated 17 Jul 2017, 22:31:58 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -243,6 +243,22 @@ void listen_socket::logout_user(access_list& p)
                   << " (" << bu->control->userid << ")" << std::endl;
 
         this->send_ack(bu->control, TYPE_LGTREQ, 0);
+    }
+}
+
+void listen_socket::send_ping(Control *con)
+{
+    packet_list pkt;
+    listen_socket::users_iterator found;
+
+    if ((found = this->users.find(con->userid)) != this->users.end())
+    {
+        pkt.buf.basic.type = TYPE_PNGPKT;
+        pkt.buf.basic.version = 1;
+        pkt.buf.basic.sequence = found->second->sequence++;
+        pkt.who = con;
+        pkt.parent = this;
+        this->send_pool->push(pkt);
     }
 }
 

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -1,6 +1,6 @@
 /* listensock.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 09:13:33 tquirk
+ *   last updated 18 Jul 2017, 09:29:51 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -75,9 +75,12 @@ const base_user& base_user::operator=(const base_user& u)
     return *this;
 }
 
-listen_socket::listen_socket(struct addrinfo *ai)
+listen_socket::listen_socket(struct addrinfo *ai, int rt, int pt, int ldt)
     : users(), sock(ai)
 {
+    this->reap_time = rt;
+    this->ping_time = pt;
+    this->link_dead_time = ldt;
     this->init();
 }
 
@@ -196,12 +199,12 @@ void *listen_socket::reaper_worker(void *arg)
               << ls->sock.sa->port() << std::endl;
     for (;;)
     {
-        sleep(listen_socket::REAP_TIMEOUT);
+        sleep(ls->reap_time);
         now = time(NULL);
         for (i = ls->users.begin(); i != ls->users.end(); ++i)
         {
             pthread_testcancel();
-            if (bu->timestamp < now - listen_socket::LINK_DEAD_TIMEOUT)
+            if (bu->timestamp < now - ls->link_dead_time)
             {
                 /* We'll consider the user link-dead */
                 std::clog << "removing user "
@@ -218,7 +221,7 @@ void *listen_socket::reaper_worker(void *arg)
                 ls->do_logout(bu);
                 ls->users.erase((*(i--)).second->userid);
             }
-            else if (bu->timestamp < now - listen_socket::PING_TIMEOUT
+            else if (bu->timestamp < now - ls->ping_time
                      && bu->pending_logout == false)
                 ls->send_ping(bu->control);
         }

--- a/server/classes/listensock.h
+++ b/server/classes/listensock.h
@@ -99,6 +99,7 @@ class listen_socket {
     virtual void logout_user(access_list&);
 
     virtual void do_login(uint64_t, Control *, access_list&) = 0;
+    virtual void do_logout(base_user *) = 0;
 
     virtual void send_ping(Control *);
     virtual void send_ack(Control *, uint8_t, uint8_t);

--- a/server/classes/listensock.h
+++ b/server/classes/listensock.h
@@ -1,6 +1,6 @@
 /* listensock.h                                            -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 17 Jul 2017, 22:30:03 tquirk
+ *   last updated 18 Jul 2017, 07:33:48 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -84,6 +84,8 @@ class listen_socket {
     virtual ~listen_socket();
 
     void init(void);
+
+    virtual std::string port_type(void) = 0;
 
     virtual void start(void) = 0;
     virtual void stop(void);

--- a/server/classes/listensock.h
+++ b/server/classes/listensock.h
@@ -1,6 +1,6 @@
 /* listensock.h                                            -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 06 Jul 2017, 10:10:56 tquirk
+ *   last updated 17 Jul 2017, 22:30:03 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -98,6 +98,7 @@ class listen_socket {
 
     virtual void do_login(uint64_t, Control *, access_list&) = 0;
 
+    virtual void send_ping(Control *);
     virtual void send_ack(Control *, uint8_t, uint8_t);
 };
 

--- a/server/classes/listensock.h
+++ b/server/classes/listensock.h
@@ -87,7 +87,7 @@ class listen_socket {
 
     virtual std::string port_type(void) = 0;
 
-    virtual void start(void) = 0;
+    virtual void start(void);
     virtual void stop(void);
 
     static void *access_pool_worker(void *);

--- a/server/classes/listensock.h
+++ b/server/classes/listensock.h
@@ -1,6 +1,6 @@
 /* listensock.h                                            -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 09:26:35 tquirk
+ *   last updated 19 Jul 2017, 12:17:30 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -86,8 +86,6 @@ class listen_socket {
                   int = PING_TIMEOUT,
                   int = LINK_DEAD_TIMEOUT);
     virtual ~listen_socket();
-
-    void init(void);
 
     virtual std::string port_type(void) = 0;
 

--- a/server/classes/listensock.h
+++ b/server/classes/listensock.h
@@ -1,6 +1,6 @@
 /* listensock.h                                            -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 07:33:48 tquirk
+ *   last updated 18 Jul 2017, 09:26:35 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -67,6 +67,7 @@ class listen_socket {
     static const int LINK_DEAD_TIMEOUT = 75;
 
   protected:
+    int reap_time, ping_time, link_dead_time;
     bool reaper_running;
     pthread_t reaper;
 
@@ -80,7 +81,10 @@ class listen_socket {
     basesock sock;
 
   public:
-    listen_socket(struct addrinfo *);
+    listen_socket(struct addrinfo *,
+                  int = REAP_TIMEOUT,
+                  int = PING_TIMEOUT,
+                  int = LINK_DEAD_TIMEOUT);
     virtual ~listen_socket();
 
     void init(void);

--- a/server/classes/listensock.h
+++ b/server/classes/listensock.h
@@ -1,6 +1,6 @@
 /* listensock.h                                            -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 19 Jul 2017, 12:17:30 tquirk
+ *   last updated 20 Jul 2017, 08:12:42 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -67,7 +67,6 @@ class listen_socket {
     static const int LINK_DEAD_TIMEOUT = 75;
 
   protected:
-    int reap_time, ping_time, link_dead_time;
     bool reaper_running;
     pthread_t reaper;
 
@@ -81,10 +80,7 @@ class listen_socket {
     basesock sock;
 
   public:
-    listen_socket(struct addrinfo *,
-                  int = REAP_TIMEOUT,
-                  int = PING_TIMEOUT,
-                  int = LINK_DEAD_TIMEOUT);
+    listen_socket(struct addrinfo *);
     virtual ~listen_socket();
 
     virtual std::string port_type(void) = 0;

--- a/server/classes/listensock.h
+++ b/server/classes/listensock.h
@@ -91,6 +91,7 @@ class listen_socket {
     virtual void stop(void);
 
     static void *access_pool_worker(void *);
+    static void *reaper_worker(void *);
 
     virtual void login_user(access_list&);
     virtual uint64_t get_userid(login_request&);

--- a/server/classes/stream.cc
+++ b/server/classes/stream.cc
@@ -1,6 +1,6 @@
 /* stream.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 17 Jul 2017, 22:48:24 tquirk
+ *   last updated 18 Jul 2017, 07:54:55 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -251,6 +251,11 @@ stream_socket::~stream_socket()
     this->subservers.erase(this->subservers.begin(), this->subservers.end());
 
     /* Thread pools are handled by the listen_socket destructor */
+}
+
+std::string stream_socket::port_type(void)
+{
+    return "stream";
 }
 
 void stream_socket::start(void)

--- a/server/classes/stream.cc
+++ b/server/classes/stream.cc
@@ -1,6 +1,6 @@
 /* stream.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 08:34:50 tquirk
+ *   last updated 18 Jul 2017, 09:32:20 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -79,8 +79,8 @@ const stream_socket::subserver& stream_socket::subserver::operator=(const stream
     return *this;
 }
 
-stream_socket::stream_socket(struct addrinfo *ai)
-    : listen_socket(ai), subservers()
+stream_socket::stream_socket(struct addrinfo *ai, int rt, int pt, int ldt)
+    : listen_socket(ai, rt, pt, ldt), subservers()
 {
     FD_ZERO(&(this->master_readfs));
     FD_SET(this->sock.sock, &(this->master_readfs));

--- a/server/classes/stream.cc
+++ b/server/classes/stream.cc
@@ -1,6 +1,6 @@
 /* stream.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 09:32:20 tquirk
+ *   last updated 18 Jul 2017, 08:34:50 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -79,8 +79,8 @@ const stream_socket::subserver& stream_socket::subserver::operator=(const stream
     return *this;
 }
 
-stream_socket::stream_socket(struct addrinfo *ai, int rt, int pt, int ldt)
-    : listen_socket(ai, rt, pt, ldt), subservers()
+stream_socket::stream_socket(struct addrinfo *ai)
+    : listen_socket(ai), subservers()
 {
     FD_ZERO(&(this->master_readfs));
     FD_SET(this->sock.sock, &(this->master_readfs));

--- a/server/classes/stream.cc
+++ b/server/classes/stream.cc
@@ -1,6 +1,6 @@
 /* stream.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 05 Jul 2017, 21:44:59 tquirk
+ *   last updated 17 Jul 2017, 22:48:24 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -461,17 +461,8 @@ void *stream_socket::stream_reaper_worker(void *arg)
             }
             else if (stu->timestamp < now - listen_socket::PING_TIMEOUT
                      && stu->pending_logout == false)
-            {
                 /* After 30 seconds, see if the user is still there */
-                packet_list pkt;
-
-                pkt.buf.basic.type = TYPE_PNGPKT;
-                pkt.buf.basic.version = 1;
-                pkt.buf.basic.sequence = stu->sequence++;
-                pkt.who = stu->control;
-                pkt.parent = sts;
-                sts->send_pool->push(pkt);
-            }
+                sts->send_ping(stu->control);
         }
         pthread_testcancel();
     }

--- a/server/classes/stream.cc
+++ b/server/classes/stream.cc
@@ -1,6 +1,6 @@
 /* stream.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 07:54:55 tquirk
+ *   last updated 18 Jul 2017, 08:34:50 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -310,6 +310,21 @@ void stream_socket::do_login(uint64_t userid,
     users[userid] = stu;
 
     this->connect_user((base_user *)stu, al);
+}
+
+/* The do_logout method performs the only stream_socket-specific work
+ * for removing a stream user from the object.  Everything else is
+ * handled in listen_socket::reaper_worker.
+ */
+void stream_socket::do_logout(base_user *bu)
+{
+    stream_user *stu = dynamic_cast<stream_user *>(bu);
+
+    if (stu != NULL)
+        /* Tell the appropriate subserver to close and erase user
+         * stu->fd by passing the descriptor in again.
+         */
+        this->pass_fd(stu->subsrv, stu->fd);
 }
 
 void *stream_socket::stream_listen_worker(void *arg)

--- a/server/classes/stream.h
+++ b/server/classes/stream.h
@@ -1,6 +1,6 @@
 /* stream.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 07:32:37 tquirk
+ *   last updated 18 Jul 2017, 09:32:39 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -73,7 +73,10 @@ class stream_socket : public listen_socket
     int pass_fd(int, int);
 
   public:
-    stream_socket(struct addrinfo *);
+    stream_socket(struct addrinfo *,
+                  int = listen_socket::REAP_TIMEOUT,
+                  int = listen_socket::PING_TIMEOUT,
+                  int = listen_socket::LINK_DEAD_TIMEOUT);
     ~stream_socket();
 
     std::string port_type(void) override;

--- a/server/classes/stream.h
+++ b/server/classes/stream.h
@@ -81,6 +81,7 @@ class stream_socket : public listen_socket
     void start(void) override;
 
     void do_login(uint64_t, Control *, access_list&) override;
+    void do_logout(base_user *) override;
 
     static void *stream_listen_worker(void *);
     static void *stream_reaper_worker(void *);

--- a/server/classes/stream.h
+++ b/server/classes/stream.h
@@ -84,7 +84,6 @@ class stream_socket : public listen_socket
     void do_logout(base_user *) override;
 
     static void *stream_listen_worker(void *);
-    static void *stream_reaper_worker(void *);
     static void *stream_send_worker(void *);
 };
 

--- a/server/classes/stream.h
+++ b/server/classes/stream.h
@@ -1,6 +1,6 @@
 /* stream.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 Jul 2017, 09:32:39 tquirk
+ *   last updated 18 Jul 2017, 07:32:37 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -73,10 +73,7 @@ class stream_socket : public listen_socket
     int pass_fd(int, int);
 
   public:
-    stream_socket(struct addrinfo *,
-                  int = listen_socket::REAP_TIMEOUT,
-                  int = listen_socket::PING_TIMEOUT,
-                  int = listen_socket::LINK_DEAD_TIMEOUT);
+    stream_socket(struct addrinfo *);
     ~stream_socket();
 
     std::string port_type(void) override;

--- a/server/classes/stream.h
+++ b/server/classes/stream.h
@@ -1,6 +1,6 @@
 /* stream.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 06 Jul 2017, 09:59:45 tquirk
+ *   last updated 18 Jul 2017, 07:32:37 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -75,6 +75,8 @@ class stream_socket : public listen_socket
   public:
     stream_socket(struct addrinfo *);
     ~stream_socket();
+
+    std::string port_type(void) override;
 
     void start(void) override;
 

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -15,6 +15,7 @@ t_game_obj
 t_image
 t_library
 t_listensock
+t_listensock_worker
 t_log
 t_logbuf
 t_motion_pool

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -19,6 +19,7 @@ if WANT_SERVER
 	t_game_obj \
 	t_library \
 	t_listensock \
+	t_listensock_worker \
 	t_log \
 	t_motion_pool \
 	t_sockaddr \
@@ -112,6 +113,17 @@ t_listensock_SOURCES = t_listensock.cc \
 	../server/config_data.cc ../server/config_data.h
 t_listensock_CXXFLAGS = $(CONFIG_DEFS) $(GMOCK_INCLUDES) $(GTEST_INCLUDES)
 t_listensock_LDADD = $(GMOCK_MAIN_OBJ) $(GMOCK_LIBS) $(GTEST_LIBS) \
+	../proto/libr9_proto.la ../server/classes/libr9_classes.la \
+	$(SERVER_LDLIBS)
+
+t_listensock_worker_SOURCES = t_listensock_worker.cc \
+	../server/classes/listensock.cc ../server/classes/listensock.h \
+	../server/classes/modules/db.cc ../server/classes/modules/db.h \
+	../server/log.cc ../server/log.h \
+	../server/config_data.cc ../server/config_data.h
+t_listensock_worker_CXXFLAGS = $(CONFIG_DEFS) \
+	$(GMOCK_INCLUDES) $(GTEST_INCLUDES)
+t_listensock_worker_LDADD = $(GMOCK_MAIN_OBJ) $(GMOCK_LIBS) $(GTEST_LIBS) \
 	../proto/libr9_proto.la ../server/classes/libr9_classes.la \
 	$(SERVER_LDLIBS)
 

--- a/test/mock_listensock.h
+++ b/test/mock_listensock.h
@@ -11,6 +11,8 @@ class mock_listen_socket : public listen_socket
     mock_listen_socket(struct addrinfo *a) : listen_socket(a) {};
     virtual ~mock_listen_socket() {};
 
+    MOCK_METHOD0(port_type, std::string(void));
+
     MOCK_METHOD0(init, void(void));
     MOCK_METHOD0(start, void(void));
     MOCK_METHOD0(stop, void(void));

--- a/test/mock_listensock.h
+++ b/test/mock_listensock.h
@@ -24,6 +24,9 @@ class mock_listen_socket : public listen_socket
     MOCK_METHOD1(get_userid, uint64_t(login_request&));
     MOCK_METHOD2(connect_user, void(base_user *, access_list&));
 
+    MOCK_METHOD1(do_logout, void(base_user *));
+
+    MOCK_METHOD1(send_ping, void(Control *));
     MOCK_METHOD3(send_ack, void(Control *, uint8_t, uint8_t));
 
     /* Shouldn't need to mock the access_pool_worker static method,

--- a/test/t_listensock.cc
+++ b/test/t_listensock.cc
@@ -99,21 +99,6 @@ class test_listen_socket : public listen_socket
     virtual void do_logout(base_user *a) override {};
 };
 
-class broken_listen_socket : public listen_socket
-{
-  public:
-    broken_listen_socket(struct addrinfo *a) : listen_socket(a) {};
-    virtual ~broken_listen_socket() {};
-
-    virtual std::string port_type(void) override
-        {
-            return "broken";
-        };
-
-    virtual void do_login(uint64_t a, Control *b, access_list& c) override {};
-    virtual void do_logout(base_user *a) override {};
-};
-
 TEST(BaseUserTest, CreateDelete)
 {
     Control *con = new Control(0LL, NULL);
@@ -252,24 +237,6 @@ TEST(ListenSocketTest, StartStop)
         });
 
     delete listen;
-}
-
-TEST(ListenSocketTest, DeleteFailure)
-{
-    struct addrinfo *addr = create_addrinfo();
-    broken_listen_socket *listen = new broken_listen_socket(addr);
-
-    listen->start();
-
-    cancel_count = join_count = 0;
-    cancel_error = join_error = true;
-    ASSERT_NO_THROW(
-        {
-            delete listen;
-        });
-    ASSERT_GT(cancel_count, 0);
-    ASSERT_GT(join_count, 0);
-    cancel_error = join_error = false;
 }
 
 TEST(ListenSocketTest, GetUserid)

--- a/test/t_listensock.cc
+++ b/test/t_listensock.cc
@@ -106,6 +106,7 @@ class broken_listen_socket : public listen_socket
         };
 
     virtual void do_login(uint64_t a, Control *b, access_list& c) override {};
+    virtual void do_logout(base_user *a) override {};
 };
 
 TEST(BaseUserTest, CreateDelete)

--- a/test/t_listensock.cc
+++ b/test/t_listensock.cc
@@ -91,6 +91,11 @@ class broken_listen_socket : public listen_socket
     broken_listen_socket(struct addrinfo *a) : listen_socket(a) {};
     virtual ~broken_listen_socket() {};
 
+    virtual std::string port_type(void) override
+        {
+            return "broken";
+        };
+
     virtual void start(void) override
         {
             this->reaper_running = true;

--- a/test/t_listensock.cc
+++ b/test/t_listensock.cc
@@ -230,6 +230,31 @@ TEST(ListenSocketTest, StartStop)
         });
     ASSERT_GT(create_count, 1);
 
+    cancel_error = true;
+    ASSERT_THROW(
+        {
+            listen->stop();
+        },
+        std::runtime_error);
+    try { listen->stop(); }
+    catch (std::runtime_error& e)
+    {
+        ASSERT_TRUE(strstr(e.what(), "couldn't cancel reaper") != NULL);
+    }
+
+    cancel_error = false;
+    join_error = true;
+    ASSERT_THROW(
+        {
+            listen->stop();
+        },
+        std::runtime_error);
+    try { listen->stop(); }
+    catch (std::runtime_error& e)
+    {
+        ASSERT_TRUE(strstr(e.what(), "couldn't join reaper") != NULL);
+    }
+
     join_error = false;
     ASSERT_NO_THROW(
         {

--- a/test/t_listensock.cc
+++ b/test/t_listensock.cc
@@ -91,7 +91,6 @@ class test_listen_socket : public listen_socket
             return "test";
         };
 
-    virtual void start(void) override {};
     virtual void do_login(uint64_t a, Control *b, access_list& c) override
         {
             delete b;
@@ -109,15 +108,6 @@ class broken_listen_socket : public listen_socket
     virtual std::string port_type(void) override
         {
             return "broken";
-        };
-
-    virtual void start(void) override
-        {
-            this->reaper_running = true;
-        };
-    virtual void stop(void) override
-        {
-            throw std::runtime_error("argh");
         };
 
     virtual void do_login(uint64_t a, Control *b, access_list& c) override {};

--- a/test/t_listensock.cc
+++ b/test/t_listensock.cc
@@ -77,12 +77,18 @@ class test_listen_socket : public listen_socket
     test_listen_socket(struct addrinfo *a) : listen_socket(a) {};
     virtual ~test_listen_socket() {};
 
+    virtual std::string port_type(void) override
+        {
+            return "test";
+        };
+
     virtual void start(void) override {};
     virtual void do_login(uint64_t a, Control *b, access_list& c) override
         {
             delete b;
             ++login_count;
         };
+    virtual void do_logout(base_user *a) override {};
 };
 
 class broken_listen_socket : public listen_socket

--- a/test/t_listensock.cc
+++ b/test/t_listensock.cc
@@ -419,6 +419,26 @@ TEST(ListenSocketTest, Logout)
     delete control;
 }
 
+TEST(ListenSocketTest, SendPing)
+{
+    Control *control = new Control(123LL, NULL);
+    base_user *bu = new base_user(123LL, control);
+    struct addrinfo *addr = create_addrinfo();
+    listen_socket *listen;
+
+    listen = new test_listen_socket(addr);
+    listen->users[123LL] = bu;
+
+    ASSERT_TRUE(listen->send_pool->queue_size() == 0);
+
+    listen->send_ping(control);
+
+    ASSERT_TRUE(listen->send_pool->queue_size() > 0);
+
+    delete listen;
+    delete control;
+}
+
 TEST(ListenSocketTest, SendAck)
 {
     Control *control = new Control(123LL, NULL);

--- a/test/t_listensock_worker.cc
+++ b/test/t_listensock_worker.cc
@@ -1,0 +1,27 @@
+#include "../server/classes/listensock.h"
+
+#include <gtest/gtest.h>
+
+int login_count, logout_count;
+
+class test_listen_socket : public listen_socket
+{
+  public:
+    test_listen_socket(struct addrinfo *a) : listen_socket(a) {};
+    virtual ~test_listen_socket() {};
+
+    virtual std::string port_type(void) override
+        {
+            return "test";
+        };
+
+    virtual void do_login(uint64_t a, Control *b, access_list& c) override
+        {
+            delete b;
+            ++login_count;
+        };
+    virtual void do_logout(base_user *a) override
+        {
+            ++logout_count;
+        };
+};

--- a/test/t_listensock_worker.cc
+++ b/test/t_listensock_worker.cc
@@ -1,8 +1,44 @@
 #include "../server/classes/listensock.h"
+#include "../server/config_data.h"
 
+#include <stdlib.h>
+#include <unistd.h>
 #include <gtest/gtest.h>
 
-int login_count, logout_count;
+#include "mock_server_globals.h"
+
+int sleep_count, login_count, logout_count;
+
+unsigned int sleep(unsigned int a)
+{
+    ++sleep_count;
+    return a;
+}
+
+struct addrinfo *create_addrinfo(void)
+{
+    struct addrinfo hints, *addr = NULL;
+    static int port = 9876;
+    char port_str[6];
+    int ret;
+
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_DGRAM;
+    hints.ai_flags = AI_NUMERICSERV;
+    hints.ai_protocol = 0;
+    hints.ai_canonname = NULL;
+    hints.ai_addr = NULL;
+    hints.ai_next = NULL;
+
+    snprintf(port_str, sizeof(port_str), "%d", port--);
+    if ((ret = getaddrinfo(NULL, port_str, &hints, &addr)) != 0)
+    {
+        std::cerr << gai_strerror(ret) << std::endl;
+        throw std::runtime_error("getaddrinfo broke");
+    }
+
+    return addr;
+}
 
 class test_listen_socket : public listen_socket
 {

--- a/test/t_listensock_worker.cc
+++ b/test/t_listensock_worker.cc
@@ -90,10 +90,11 @@ TEST(ListenSocketTest, ReaperWorker)
 
     listen->start();
 
-    /* Since we have mocked out sleep(), we'll run the system sleep(1)
-     * command to give the reaper a chance to do its work.
+    /* The user will be deleted absolutely last, so that's what we
+     * need to wait for.
      */
-    system("sleep 1");
+    while (listen->users.size() > 1)
+        ;
 
     listen->stop();
 


### PR DESCRIPTION
Refactor the listen_socket and its children to reduce duplicated code, and simplify the data flow through the object.  Also clean up the tests and improve coverage as much as possible.