### PR TITLE
Fix strerror

### DIFF
--- a/client/configdata.cc
+++ b/client/configdata.cc
@@ -1,9 +1,9 @@
 /* configdata.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 08 Sep 2016, 19:29:38 tquirk
+ *   last updated 26 Feb 2018, 07:36:54 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2016  Trinity Annabelle Quirk
+ * Copyright (C) 2018  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -236,8 +236,11 @@ void ConfigData::make_config_dirs(void)
     if (mkdir(dirname.c_str(), 0700) == -1 && errno != EEXIST)
     {
         std::ostringstream s;
+        char err[128];
+
+        strerror_r(errno, err, sizeof(err));
         s << "Error creating r9 preferences directory " << dirname << ": "
-          << strerror(errno) << " (" << errno << ")";
+          << err << " (" << errno << ")";
         throw std::runtime_error(s.str());
     }
 
@@ -246,8 +249,11 @@ void ConfigData::make_config_dirs(void)
     if (mkdir(subdirname.c_str(), 0700) == -1 && errno != EEXIST)
     {
         std::ostringstream s;
+        char err[128];
+
+        strerror_r(errno, err, sizeof(err));
         s << "Can't make config directory " << subdirname << ": "
-          << strerror(errno) << " (" << errno << ")";
+          << err << " (" << errno << ")";
         throw std::runtime_error(s.str());
     }
 
@@ -255,8 +261,11 @@ void ConfigData::make_config_dirs(void)
     if (mkdir(subdirname.c_str(), 0700) == -1 && errno != EEXIST)
     {
         std::ostringstream s;
+        char err[128];
+
+        strerror_r(errno, err, sizeof(err));
         s << "Can't make config directory " << subdirname << ": "
-          << strerror(errno) << " (" << errno << ")";
+          << err << " (" << errno << ")";
         throw std::runtime_error(s.str());
     }
 
@@ -264,8 +273,11 @@ void ConfigData::make_config_dirs(void)
     if (mkdir(subdirname.c_str(), 0700) == -1 && errno != EEXIST)
     {
         std::ostringstream s;
+        char err[128];
+
+        strerror_r(errno, err, sizeof(err));
         s << "Can't make config directory " << subdirname << ": "
-          << strerror(errno) << " (" << errno << ")";
+          << err << " (" << errno << ")";
         throw std::runtime_error(s.str());
     }
 }

--- a/client/log_display.cc
+++ b/client/log_display.cc
@@ -1,9 +1,9 @@
 /* log_display.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 26 Nov 2017, 08:03:45 tquirk
+ *   last updated 26 Feb 2018, 07:40:44 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2017  Trinity Annabelle Quirk
+ * Copyright (C) 2018  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -194,8 +194,11 @@ log_display::log_display(ui::composite *p, GLuint w, GLuint h)
                               log_display::cleanup_entries, (void *)this)) != 0)
     {
         std::ostringstream s;
+        char err[128];
+
+        strerror_r(ret, err, sizeof(err));
         s << "Couldn't start log display cleanup thread: "
-          << strerror(ret) << " (" << ret << ")";
+          << err << " (" << ret << ")";
         throw std::runtime_error(s.str());
     }
 
@@ -212,15 +215,30 @@ log_display::~log_display()
     std::clog.rdbuf(this->orig_rdbuf);
 
     if ((ret = pthread_cancel(this->cleanup_thread)) != 0)
+    {
+        char err[128];
+
+        strerror_r(ret, err, sizeof(err));
         std::clog << "Couldn't cancel log display cleanup thread: "
-                  << strerror(ret) << " (" << ret << ")" << std::endl;
+                  << err << " (" << ret << ")" << std::endl;
+    }
     sleep(0);
     if ((ret = pthread_join(this->cleanup_thread, NULL)) != 0)
+    {
+        char err[128];
+
+        strerror_r(ret, err, sizeof(err));
         std::clog << "Couldn't reap log display cleanup thread: "
-                  << strerror(ret) << " (" << ret << ")" << std::endl;
+                  << err << " (" << ret << ")" << std::endl;
+    }
     if ((ret = pthread_mutex_destroy(&this->queue_mutex)) != 0)
+    {
+        char err[128];
+
+        strerror_r(ret, err, sizeof(err));
         std::clog << "Couldn't destroy log display mutex: "
-                  << strerror(ret) << " (" << ret << ")" << std::endl;
+                  << err << " (" << ret << ")" << std::endl;
+    }
 
     this->sync_to_file();
 }

--- a/config.h.in
+++ b/config.h.in
@@ -179,9 +179,6 @@
 /* Define to 1 if you have the `strdup' function. */
 #undef HAVE_STRDUP
 
-/* Define to 1 if you have the `strerror' function. */
-#undef HAVE_STRERROR
-
 /* Define to 1 if you have the `strerror_r' function. */
 #undef HAVE_STRERROR_R
 

--- a/config.h.in
+++ b/config.h.in
@@ -182,6 +182,9 @@
 /* Define to 1 if you have the `strerror' function. */
 #undef HAVE_STRERROR
 
+/* Define to 1 if you have the `strerror_r' function. */
+#undef HAVE_STRERROR_R
+
 /* Define to 1 if you have the <strings.h> header file. */
 #undef HAVE_STRINGS_H
 

--- a/config.h.in
+++ b/config.h.in
@@ -239,9 +239,6 @@
 /* Define to 1 if `vfork' works. */
 #undef HAVE_WORKING_VFORK
 
-/* Define to 1 if you have the <xercesc/sax/AttributeList.hpp> header file. */
-#undef HAVE_XERCESC_SAX_ATTRIBUTELIST_HPP
-
 /* Define to 1 if the system has the type `_Bool'. */
 #undef HAVE__BOOL
 

--- a/configure.ac
+++ b/configure.ac
@@ -381,7 +381,7 @@ AC_TYPE_UINT64_T
 # Checks for library functions.
 AC_FUNC_FORK
 AC_FUNC_MALLOC
-AC_CHECK_FUNCS([backtrace dup2 getcwd gethostname gettimeofday getrlimit htonll kill memset mkdir nanosleep ntohll select socket strdup strerror strerror_r strtoull])
+AC_CHECK_FUNCS([backtrace dup2 getcwd gethostname gettimeofday getrlimit htonll kill memset mkdir nanosleep ntohll select socket strdup strerror_r strtoull])
 
 # One of the mocks in our test suite needs a possibly-different
 # prototype, depending on the system we're building on.

--- a/configure.ac
+++ b/configure.ac
@@ -381,7 +381,7 @@ AC_TYPE_UINT64_T
 # Checks for library functions.
 AC_FUNC_FORK
 AC_FUNC_MALLOC
-AC_CHECK_FUNCS([backtrace dup2 getcwd gethostname gettimeofday getrlimit htonll kill memset mkdir nanosleep ntohll select socket strdup strerror strtoull])
+AC_CHECK_FUNCS([backtrace dup2 getcwd gethostname gettimeofday getrlimit htonll kill memset mkdir nanosleep ntohll select socket strdup strerror strerror_r strtoull])
 
 # One of the mocks in our test suite needs a possibly-different
 # prototype, depending on the system we're building on.

--- a/server/classes/dgram.cc
+++ b/server/classes/dgram.cc
@@ -1,9 +1,9 @@
 /* dgram.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 26 Sep 2017, 13:07:27 tquirk
+ *   last updated 27 Feb 2018, 07:40:14 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2017  Trinity Annabelle Quirk
+ * Copyright (C) 2018  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -200,11 +200,16 @@ void *dgram_socket::dgram_send_worker(void *arg)
                        (void *)&req.buf, realsize, 0,
                        dgs->user_socks[bu->userid]->sockaddr(),
                        sizeof(struct sockaddr_storage)) == -1)
+            {
+                char err[128];
+
+                strerror_r(errno, err, sizeof(err));
                 std::clog << syslogErr
                           << "error sending packet out datagram port "
                           << dgs->sock.sa->port() << ": "
-                          << strerror(errno) << " (" << errno << ")"
+                          << err << " (" << errno << ")"
                           << std::endl;
+            }
         }
     }
     std::clog << "exiting send pool worker for datagram port "

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -1,6 +1,6 @@
 /* listensock.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 25 Feb 2018, 15:21:42 tquirk
+ *   last updated 27 Feb 2018, 07:31:30 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -138,10 +138,13 @@ void listen_socket::start(void)
                                  reaper_worker, (void *)this)) != 0)
     {
         std::ostringstream s;
+        char err[128];
+
+        strerror_r(retval, err, sizeof(err));
         s << "couldn't create reaper thread for "
           << this->port_type() << " port "
           << this->sock.sa->port() << ": "
-          << strerror(retval) << " (" << retval << ")";
+          << err << " (" << retval << ")";
         throw std::runtime_error(s.str());
     }
     this->reaper_running = true;
@@ -160,18 +163,24 @@ void listen_socket::stop(void)
         if ((retval = pthread_cancel(this->reaper)) != 0)
         {
             std::ostringstream s;
+            char err[128];
+
+            strerror_r(retval, err, sizeof(err));
             s << "couldn't cancel reaper thread for " << this->port_type()
               << " port " << this->sock.sa->port() << ": "
-              << strerror(retval) << " (" << retval << ")";
+              << err << " (" << retval << ")";
             throw std::runtime_error(s.str());
         }
         sleep(0);
         if ((retval = pthread_join(this->reaper, NULL)) != 0)
         {
             std::ostringstream s;
+            char err[128];
+
+            strerror_r(retval, err, sizeof(err));
             s << "couldn't join reaper thread for " << this->port_type()
               << " port " << this->sock.sa->port() << ": "
-              << strerror(retval) << " (" << retval << ")";
+              << err << " (" << retval << ")";
             throw std::runtime_error(s.str());
         }
         this->reaper_running = false;

--- a/server/classes/modules/console.cc
+++ b/server/classes/modules/console.cc
@@ -1,9 +1,9 @@
 /* console.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 26 Sep 2017, 13:00:22 tquirk
+ *   last updated 27 Feb 2018, 07:47:47 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2017  Trinity Annabelle Quirk
+ * Copyright (C) 2018  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -62,8 +62,10 @@ ConsoleSession::ConsoleSession(int sock)
                               (void *)this)) != 0)
     {
         std::ostringstream s;
-        s << "error creating console thread: "
-          << strerror(ret) << " (" << ret << ")";
+        char err[128];
+
+        strerror_r(ret, err, sizeof(err));
+        s << "error creating console thread: " << err << " (" << ret << ")";
         throw std::runtime_error(s.str());
     }
 }

--- a/server/classes/modules/db.cc
+++ b/server/classes/modules/db.cc
@@ -1,9 +1,9 @@
 /* db.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Nov 2015, 16:59:39 tquirk
+ *   last updated 27 Feb 2018, 07:51:03 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2015  Trinity Annabelle Quirk
+ * Copyright (C) 2018  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -52,8 +52,10 @@ void DB::get_host_address(void)
     if ((ret = gethostname(hostname, sizeof(hostname))) != 0)
     {
         std::ostringstream s;
-        s << "couldn't get hostname: "
-          << strerror(errno) << " (" << errno << ")";
+        char err[128];
+
+        strerror_r(errno, err, sizeof(err));
+        s << "couldn't get hostname: " << err << " (" << errno << ")";
         throw std::runtime_error(s.str());
     }
     if ((ret = getaddrinfo(hostname, NULL, NULL, &info)) != 0)
@@ -70,8 +72,11 @@ void DB::get_host_address(void)
                   this->host_ip, INET6_ADDRSTRLEN) == NULL)
     {
         std::ostringstream s;
+        char err[128];
+
+        strerror_r(errno, err, sizeof(err));
         s << "couldn't convert IP for " << hostname << " into a string: "
-          << strerror(errno) << " (" << errno << ")";
+          << err << " (" << errno << ")";
         throw std::runtime_error(s.str());
     }
     freeaddrinfo(info);

--- a/server/classes/stream.cc
+++ b/server/classes/stream.cc
@@ -1,9 +1,9 @@
 /* stream.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 26 Sep 2017, 12:59:47 tquirk
+ *   last updated 27 Feb 2018, 07:39:20 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2017  Trinity Annabelle Quirk
+ * Copyright (C) 2018  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -194,10 +194,13 @@ int stream_socket::select_fd_set(void)
         }
         else
         {
+            char err[128];
+
+            strerror_r(errno, err, sizeof(err));
             std::clog << syslogErr
                       << "select error in stream port "
                       << this->sock.sa->port() << ": "
-                      << strerror(errno) << " (" << errno << ")"
+                      << err << " (" << errno << ")"
                       << std::endl;
         }
     }
@@ -282,12 +285,17 @@ void *stream_socket::stream_send_worker(void *arg)
             fd = sts->user_fds[req.who->userid];
             /* TODO: Encryption */
             if (write(fd, (void *)&req, realsize) == -1)
+            {
+                char err[128];
+
+                strerror_r(errno, err, sizeof(err));
                 std::clog << syslogErr
                           << "error sending packet out stream port "
                           << sts->sock.sa->port() << ", user port "
                           << fd << ": "
-                          << strerror(errno) << " (" << errno << ")"
+                          << err << " (" << errno << ")"
                           << std::endl;
+            }
         }
     }
     std::clog << "exiting send pool worker for stream port "

--- a/server/classes/thread_pool.h
+++ b/server/classes/thread_pool.h
@@ -1,9 +1,9 @@
 /* thread_pool.h                                           -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 26 Sep 2017, 13:10:29 tquirk
+ *   last updated 27 Feb 2018, 07:43:46 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2017  Trinity Annabelle Quirk
+ * Copyright (C) 2018  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -105,15 +105,21 @@ class ThreadPool
             if ((ret = pthread_mutex_init(&(this->queue_lock), NULL)) != 0)
             {
                 std::ostringstream s;
+                char err[128];
+
+                strerror_r(ret, err, sizeof(err));
                 s << "couldn't init " << this->name << " queue mutex: "
-                  << strerror(ret) << " (" << ret << ")";
+                  << err << " (" << ret << ")";
                 throw std::runtime_error(s.str());
             }
             if ((ret = pthread_cond_init(&(this->queue_not_empty), NULL)) != 0)
             {
                 std::ostringstream s;
+                char err[128];
+
+                strerror_r(ret, err, sizeof(err));
                 s << "couldn't init " << this->name << " queue not-empty cond: "
-                  << strerror(ret) << " (" << ret << ")";
+                  << err << " (" << ret << ")";
                 pthread_mutex_destroy(&(this->queue_lock));
                 throw std::runtime_error(s.str());
             }
@@ -148,8 +154,11 @@ class ThreadPool
                                           this->startup_arg)) != 0)
                 {
                     std::ostringstream s;
+                    char err[128];
+
+                    strerror_r(ret, err, sizeof(err));
                     s << "couldn't start a " << this->name << " thread: "
-                      << strerror(ret) << " (" << ret << ")";
+                      << err << " (" << ret << ")";
                     /* Something's messed up; stop all the threads */
                     pthread_mutex_unlock(&(this->queue_lock));
                     this->stop();

--- a/server/server.cc
+++ b/server/server.cc
@@ -1,6 +1,6 @@
 /* server.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 01 Feb 2018, 08:28:05 tquirk
+ *   last updated 27 Feb 2018, 07:54:23 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -178,7 +178,10 @@ static void setup_daemon(void)
         if ((pid = fork()) < 0)
         {
             std::ostringstream s;
-            s << "failed to fork: " << strerror(errno) << " (" << errno << ")";
+            char err[128];
+
+            strerror_r(errno, err, sizeof(err));
+            s << "failed to fork: " << err << " (" << errno << ")";
             throw std::runtime_error(s.str());
         }
         else if (pid != 0)
@@ -203,8 +206,10 @@ static void setup_daemon(void)
     {
         /* Apparently another invocation is running, so we can't. */
         std::ostringstream s;
-        s << "couldn't create lock file: " << strerror(errno)
-          << " (" << errno << ")";
+        char err[128];
+
+        strerror_r(errno, err, sizeof(err));
+        s << "couldn't create lock file: " << err << " (" << errno << ")";
         throw std::runtime_error(s.str());
     }
     if (config.daemonize)

--- a/server/signals.cc
+++ b/server/signals.cc
@@ -1,9 +1,9 @@
 /* signals.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 26 Sep 2017, 13:28:52 tquirk
+ *   last updated 27 Feb 2018, 07:56:07 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2016  Trinity Annabelle Quirk
+ * Copyright (C) 2018  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -75,37 +75,67 @@ void setup_signals(void)
     sa.sa_mask = ss;
     sa.sa_flags = 0;
     if (sigaction(SIGHUP, &sa, NULL) == -1)
+    {
+        char err[128];
+
+        strerror_r(errno, err, sizeof(err));
         std::clog << syslogErr << "couldn't set SIGHUP handler: "
-                  << strerror(errno) << " (" << errno << ")" << std::endl;
+                  << err << " (" << errno << ")" << std::endl;
+    }
     /* SIGHUP - reread the configuration files. */
     sa.sa_handler = sigusr1_handler;
     if (sigaction(SIGUSR1, &sa, NULL) == -1)
+    {
+        char err[128];
+
+        strerror_r(errno, err, sizeof(err));
         std::clog << syslogErr << "couldn't set SIGUSR1 handler: "
-                  << strerror(errno) << " (" << errno << ")" << std::endl;
+                  << err << " (" << errno << ")" << std::endl;
+    }
     /* SIGUSR2 - recreate the zone. */
     sa.sa_handler = sigusr2_handler;
     if (sigaction(SIGUSR2, &sa, NULL) == -1)
+    {
+        char err[128];
+
+        strerror_r(errno, err, sizeof(err));
         std::clog << syslogErr << "couldn't set SIGUSR2 handler: "
-                  << strerror(errno) << " (" << errno << ")" << std::endl;
+                  << err << " (" << errno << ")" << std::endl;
+    }
     /* SIGTERM - terminate the process normally. */
     sa.sa_handler = sigterm_handler;
     sigaddset(&ss, SIGTERM);
     sa.sa_mask = ss;
     if (sigaction(SIGTERM, &sa, NULL) == -1)
+    {
+        char err[128];
+
+        strerror_r(errno, err, sizeof(err));
         std::clog << syslogErr << "couldn't set SIGTERM handler: "
-                  << strerror(errno) << " (" << errno << ")" << std::endl;
+                  << err << " (" << errno << ")" << std::endl;
+    }
     /* SIGINT - terminate the process normally. */
     sa.sa_handler = sigint_handler;
     sigaddset(&ss, SIGINT);
     sa.sa_mask = ss;
     if (sigaction(SIGINT, &sa, NULL) == -1)
+    {
+        char err[128];
+
+        strerror_r(errno, err, sizeof(err));
         std::clog << syslogErr << "couldn't set SIGINT handler: "
-                  << strerror(errno) << " (" << errno << ")" << std::endl;
+                  << err << " (" << errno << ")" << std::endl;
+    }
     /* SIGSEGV - clean up and terminate the process. */
     sa.sa_handler = sigsegv_handler;
     if (sigaction(SIGSEGV, &sa, NULL) == -1)
+    {
+        char err[128];
+
+        strerror_r(errno, err, sizeof(err));
         std::clog << syslogErr << "couldn't set SIGSEGV handler: "
-                  << strerror(errno) << " (" << errno << ")" << std::endl;
+                  << err << " (" << errno << ")" << std::endl;
+    }
 }
 
 /* Reset the signal handlers to the default actions. */

--- a/test/t_console.cc
+++ b/test/t_console.cc
@@ -51,7 +51,10 @@ void send_data_to(short port)
     if ((sock = socket(PF_INET, SOCK_STREAM, 0)) < 0)
     {
         std::ostringstream s;
-        s << "socket error: " << strerror(errno) << " (" << errno << ')';
+        char err[128];
+
+        strerror_r(errno, err, sizeof(err));
+        s << "socket error: " << err << " (" << errno << ')';
         throw std::runtime_error(s.str());
     }
     std::cerr << "sock opened" << std::endl;
@@ -59,7 +62,10 @@ void send_data_to(short port)
     if (connect(sock, ai->ai_addr, ai->ai_addrlen) < 0)
     {
         std::ostringstream s;
-        s << "connect error: " << strerror(errno) << " (" << errno << ')';
+        char err[128];
+
+        strerror_r(errno, err, sizeof(err));
+        s << "connect error: " << err << " (" << errno << ')';
         throw std::runtime_error(s.str());
     }
     std::cerr << "connected" << std::endl;


### PR DESCRIPTION
Remove instances of `strerror` in favor of the thread-safe `strerror_r`.  We probably go further than we strictly need to here, but might as well remove all possible doubt.