### PR TITLE
Remove freetype checking in configure

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -52,9 +52,6 @@
 /* Define to 1 if you have the `fork' function. */
 #undef HAVE_FORK
 
-/* Define to 1 if you have the <ft2build.h> header file. */
-#undef HAVE_FT2BUILD_H
-
 /* Define to 1 if you have the `getcwd' function. */
 #undef HAVE_GETCWD
 

--- a/configure.ac
+++ b/configure.ac
@@ -210,19 +210,6 @@ then
       [AC_MSG_ERROR([ not valid, can not build client program.])],
       [$CLIENT_LDFLAGS])
 
-  # Check for Freetype2
-  FREETYPE_CPPFLAGS_SAVE="$CPPFLAGS"
-  CPPFLAGS="$CXXFLAGS"
-  AC_CHECK_HEADERS([ft2build.h], [], [AC_MSG_ERROR([no valid Freetype2 headers found, can not continue])])
-  CPPFLAGS="$FREETYPE_CPPFLAGS_SAVE"
-  AC_SEARCH_LIBS([FT_Init_FreeType], [freetype],
-      [
-          FREETYPE_LDLIBS="$ac_cv_search_FT_Init_FreeType"
-          CLIENT_LDLIBS="$FREETYPE_LDLIBS $CLIENT_LDLIBS"
-      ],
-      [AC_MSG_ERROR([ not valid, can not build client program.])],
-      [$CLIENT_LDFLAGS])
-
   CLIENT_CXXFLAGS="$DEBUG_CXXFLAGS $PROFILE_CXXFLAGS $CLIENT_CXXFLAGS"
   CLIENT_LDFLAGS="$DEBUG_LDFLAGS $PROFILE_LDFLAGS $CLIENT_LDFLAGS"
   CLIENT_LDLIBS="$CLIENT_LDLIBS $PROFILE_LDLIBS"


### PR DESCRIPTION
We no longer use freetype directly; only our subpackage cuddly-gl
does.  There's no need to do any checking at all for it in the
configure script.

Re:  issue #185