### PR TITLE
Shorten the protocol sequence field to 32 bits

### DIFF
--- a/client/comm.cc
+++ b/client/comm.cc
@@ -1,6 +1,6 @@
 /* comm.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 14 Apr 2018, 21:29:41 tquirk
+ *   last updated 16 Apr 2018, 07:42:05 tquirk
  *
  * Revision IX game client
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -67,7 +67,7 @@
 #include "client_core.h"
 #include "comm.h"
 
-uint64_t Comm::sequence = 0LL;
+uint32_t Comm::sequence = 0L;
 
 /* Jump table for protocol handling */
 Comm::pkt_handler Comm::pkt_type[] =

--- a/client/comm.h
+++ b/client/comm.h
@@ -1,6 +1,6 @@
 /* comm.h                                                  -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 10 Mar 2018, 08:57:35 tquirk
+ *   last updated 16 Apr 2018, 07:33:49 tquirk
  *
  * Revision IX game client
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -65,7 +65,7 @@ class Comm
     pthread_cond_t send_queue_not_empty;
     std::queue<packet *> send_queue;
 
-    static uint64_t sequence;
+    static uint32_t sequence;
     uint64_t src_object_id;
     volatile bool thread_exit_flag;
 

--- a/config.h.in
+++ b/config.h.in
@@ -251,7 +251,8 @@
 /* Define to the extension used for runtime loadable modules, say, ".so". */
 #undef LT_MODULE_EXT
 
-/* Define to the sub-directory where libtool stores uninstalled libraries. */
+/* Define to the sub-directory in which libtool stores uninstalled libraries.
+   */
 #undef LT_OBJDIR
 
 /* Define to the shared library suffix, say, ".dylib". */

--- a/proto/byteswap.c
+++ b/proto/byteswap.c
@@ -1,6 +1,6 @@
 /* byteswap.c
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 14 Apr 2018, 21:21:22 tquirk
+ *   last updated 16 Apr 2018, 07:35:55 tquirk
  *
  * Revision IX game protocol
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -121,7 +121,7 @@ static int hton_basic_packet(packet *ap, size_t s)
 {
     if (s < sizeof(basic_packet))
         return 0;
-    ap->basic.sequence = htonll(ap->basic.sequence);
+    ap->basic.sequence = htonl(ap->basic.sequence);
     return 1;
 }
 
@@ -130,7 +130,7 @@ static int ntoh_basic_packet(packet *ap, size_t s)
 {
     if (s < sizeof(basic_packet))
         return 0;
-    ap->basic.sequence = ntohll(ap->basic.sequence);
+    ap->basic.sequence = ntohl(ap->basic.sequence);
     return 1;
 }
 
@@ -139,7 +139,7 @@ static int hton_ack_packet(packet *ap, size_t s)
 {
     if (s < sizeof(ack_packet))
         return 0;
-    ap->ack.sequence = htonll(ap->ack.sequence);
+    ap->ack.sequence = htonl(ap->ack.sequence);
     ap->ack.misc[0] = htonll(ap->ack.misc[0]);
     ap->ack.misc[1] = htonll(ap->ack.misc[1]);
     ap->ack.misc[2] = htonll(ap->ack.misc[2]);
@@ -152,7 +152,7 @@ static int ntoh_ack_packet(packet *ap, size_t s)
 {
     if (s < sizeof(ack_packet))
         return 0;
-    ap->ack.sequence = ntohll(ap->ack.sequence);
+    ap->ack.sequence = ntohl(ap->ack.sequence);
     ap->ack.misc[0] = ntohll(ap->ack.misc[0]);
     ap->ack.misc[1] = ntohll(ap->ack.misc[1]);
     ap->ack.misc[2] = ntohll(ap->ack.misc[2]);
@@ -165,7 +165,7 @@ static int hton_login_request(packet *lr, size_t s)
 {
     if (s < sizeof(login_request))
         return 0;
-    lr->log.sequence = htonll(lr->log.sequence);
+    lr->log.sequence = htonl(lr->log.sequence);
     return 1;
 }
 
@@ -174,7 +174,7 @@ static int ntoh_login_request(packet *lr, size_t s)
 {
     if (s < sizeof(login_request))
         return 0;
-    lr->log.sequence = ntohll(lr->log.sequence);
+    lr->log.sequence = ntohl(lr->log.sequence);
     return 1;
 }
 
@@ -183,7 +183,7 @@ static int hton_action_request(packet *ar, size_t s)
 {
     if (s < sizeof(action_request))
         return 0;
-    ar->act.sequence = htonll(ar->act.sequence);
+    ar->act.sequence = htonl(ar->act.sequence);
     ar->act.object_id = htonll(ar->act.object_id);
     ar->act.action_id = htons(ar->act.action_id);
     ar->act.x_pos_source = htonll(ar->act.x_pos_source);
@@ -201,7 +201,7 @@ static int ntoh_action_request(packet *ar, size_t s)
 {
     if (s < sizeof(action_request))
         return 0;
-    ar->act.sequence = ntohll(ar->act.sequence);
+    ar->act.sequence = ntohl(ar->act.sequence);
     ar->act.object_id = ntohll(ar->act.object_id);
     ar->act.action_id = ntohs(ar->act.action_id);
     ar->act.x_pos_source = ntohll(ar->act.x_pos_source);
@@ -219,7 +219,7 @@ static int hton_position_update(packet *pu, size_t s)
 {
     if (s < sizeof(position_update))
         return 0;
-    pu->pos.sequence = htonll(pu->pos.sequence);
+    pu->pos.sequence = htonl(pu->pos.sequence);
     pu->pos.object_id = htonll(pu->pos.object_id);
     pu->pos.frame_number = htons(pu->pos.frame_number);
     pu->pos.x_pos = htonll(pu->pos.x_pos);
@@ -240,7 +240,7 @@ static int ntoh_position_update(packet *pu, size_t s)
 {
     if (s < sizeof(position_update))
         return 0;
-    pu->pos.sequence = ntohll(pu->pos.sequence);
+    pu->pos.sequence = ntohl(pu->pos.sequence);
     pu->pos.object_id = ntohll(pu->pos.object_id);
     pu->pos.frame_number = ntohs(pu->pos.frame_number);
     pu->pos.x_pos = ntohll(pu->pos.x_pos);

--- a/proto/proto.h
+++ b/proto/proto.h
@@ -1,6 +1,6 @@
 /* proto.h
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 14 Apr 2018, 21:21:13 tquirk
+ *   last updated 16 Apr 2018, 07:33:13 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -84,7 +84,7 @@ typedef struct basic_packet_tag
 {
     uint8_t type;
     uint8_t version;
-    uint64_t sequence;
+    uint32_t sequence;
 } __attribute__ ((__packed__))
 basic_packet;
 
@@ -95,7 +95,7 @@ typedef struct ack_packet_tag
 {
     uint8_t type;
     uint8_t version;        /* protocol version number */
-    uint64_t sequence;      /* timestamp / sequence number */
+    uint32_t sequence;      /* timestamp / sequence number */
     uint8_t request;        /* packet type of original request */
     uint64_t misc[4];       /* miscellaneous data */
 } __attribute__ ((__packed__))
@@ -105,7 +105,7 @@ typedef struct login_request_tag
 {
     uint8_t type;
     uint8_t version;        /* protocol version number */
-    uint64_t sequence;      /* timestamp / sequence number */
+    uint32_t sequence;      /* timestamp / sequence number */
     char username[64];
     char password[64];
     char charname[64];
@@ -116,7 +116,7 @@ typedef struct action_request_tag
 {
     uint8_t type;
     uint8_t version;        /* protocol version number */
-    uint64_t sequence;      /* timestamp / sequence number */
+    uint32_t sequence;      /* timestamp / sequence number */
     uint64_t object_id;
     uint16_t action_id;
     uint8_t power_level;
@@ -139,7 +139,7 @@ typedef struct position_update_tag
 {
     uint8_t type;
     uint8_t version;        /* protocol version number */
-    uint64_t sequence;      /* timestamp / sequence number */
+    uint32_t sequence;      /* timestamp / sequence number */
     uint64_t object_id;
     uint16_t frame_number;
     /* We may consider adding the sector vector back in here */
@@ -154,7 +154,7 @@ typedef struct server_notice_tag
 {
     uint8_t type;
     uint8_t version;        /* protocol version number */
-    uint64_t sequence;      /* timestamp / sequence number */
+    uint32_t sequence;      /* timestamp / sequence number */
     uint8_t ipproto;        /* 4 or 6 */
     char addr[INET6_ADDRSTRLEN];
     in_port_t port;

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -1,6 +1,6 @@
 /* listensock.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 14 Apr 2018, 21:25:05 tquirk
+ *   last updated 16 Apr 2018, 07:37:14 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -46,7 +46,7 @@ base_user::base_user(uint64_t u, GameObject *g, listen_socket *l)
     this->timestamp = time(NULL);
     this->pending_logout = false;
     /* Come up with some sort of random sequence number to start? */
-    this->sequence = 0LL;
+    this->sequence = 0L;
     this->characterid = 0LL;
 }
 

--- a/server/classes/listensock.h
+++ b/server/classes/listensock.h
@@ -1,9 +1,9 @@
 /* listensock.h                                            -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 21 Jan 2018, 09:10:50 tquirk
+ *   last updated 16 Apr 2018, 07:36:57 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2017  Trinity Annabelle Quirk
+ * Copyright (C) 2018  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -42,7 +42,8 @@ class listen_socket;
 
 class base_user : public Control {
   public:
-    uint64_t sequence, characterid;
+    uint32_t sequence;
+    uint64_t characterid;
     time_t timestamp;
     bool pending_logout;
     uint8_t auth_level;

--- a/test/t_action_pool.cc
+++ b/test/t_action_pool.cc
@@ -163,7 +163,6 @@ void test_no_skill(void)
     memset(&pkt, 0, sizeof(action_request));
     pkt.type = TYPE_ACTREQ;
     pkt.version = 1;
-    pkt.sequence = 1LL;
     pkt.object_id = 9876LL;
     pkt.action_id = 12345;
     pkt.power_level = 5;
@@ -198,7 +197,6 @@ void test_invalid_skill(void)
     memset(&pkt, 0, sizeof(action_request));
     pkt.type = TYPE_ACTREQ;
     pkt.version = 1;
-    pkt.sequence = 1LL;
     pkt.object_id = 9876LL;
     pkt.action_id = 567;
     pkt.power_level = 5;
@@ -233,7 +231,6 @@ void test_wrong_object_id(void)
     memset(&pkt, 0, sizeof(action_request));
     pkt.type = TYPE_ACTREQ;
     pkt.version = 1;
-    pkt.sequence = 1LL;
     pkt.object_id = 123LL;
     pkt.action_id = 789;
     pkt.power_level = 5;
@@ -268,7 +265,6 @@ void test_good_object_id(void)
     memset(&pkt, 0, sizeof(action_request));
     pkt.type = TYPE_ACTREQ;
     pkt.version = 1;
-    pkt.sequence = 1LL;
     pkt.object_id = 9876LL;
     pkt.action_id = 789;
     pkt.power_level = 5;
@@ -303,7 +299,6 @@ void test_worker(void)
     memset(&pl.buf, 0, sizeof(action_request));
     pl.buf.act.type = TYPE_ACTREQ;
     pl.buf.act.version = 1;
-    pl.buf.act.sequence = 1LL;
     pl.buf.act.object_id = 9876LL;
     pl.buf.act.action_id = 789;
     pl.buf.act.power_level = 5;


### PR DESCRIPTION
We simply don't need the extra length of a 64-bit sequence field,
so we'll shift to 32 bits.  It's long enough to do what we want to
do, and short enough that it's not a burden to handle.

Re:  issue #197