### PR TITLE
Remove volatile

### DIFF
--- a/client/comm.cc
+++ b/client/comm.cc
@@ -1,6 +1,6 @@
 /* comm.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 16 Apr 2018, 07:42:05 tquirk
+ *   last updated 19 Apr 2018, 07:45:37 tquirk
  *
  * Revision IX game client
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -282,7 +282,7 @@ void Comm::handle_unsupported(packet& p)
 }
 
 Comm::Comm(struct addrinfo *ai)
-    : send_queue()
+    : send_queue(), thread_exit_flag(false)
 {
     int ret;
 

--- a/client/comm.h
+++ b/client/comm.h
@@ -1,6 +1,6 @@
 /* comm.h                                                  -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 16 Apr 2018, 07:33:49 tquirk
+ *   last updated 19 Apr 2018, 07:44:02 tquirk
  *
  * Revision IX game client
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -48,6 +48,7 @@
 #include <cstdint>
 #include <string>
 #include <queue>
+#include <atomic>
 
 #include <glm/vec3.hpp>
 
@@ -67,7 +68,7 @@ class Comm
 
     static uint32_t sequence;
     uint64_t src_object_id;
-    volatile bool thread_exit_flag;
+    std::atomic<bool> thread_exit_flag;
 
     typedef void (Comm::*pkt_handler)(packet&);
     static pkt_handler pkt_type[7];

--- a/server/classes/dgram.cc
+++ b/server/classes/dgram.cc
@@ -1,6 +1,6 @@
 /* dgram.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 27 Feb 2018, 07:40:14 tquirk
+ *   last updated 19 Apr 2018, 07:38:14 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -43,8 +43,6 @@
 #include "log.h"
 
 #include "../server.h"
-
-extern volatile int main_loop_exit_flag;
 
 static std::map<int, listen_socket::packet_handler> packet_handlers =
 {

--- a/server/classes/stream.cc
+++ b/server/classes/stream.cc
@@ -1,6 +1,6 @@
 /* stream.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 27 Feb 2018, 07:39:20 tquirk
+ *   last updated 19 Apr 2018, 07:34:46 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -54,7 +54,7 @@
 #include "config_data.h"
 #include "log.h"
 
-extern volatile int main_loop_exit_flag;
+#include "../server.h"
 
 static std::map<int, listen_socket::packet_handler> packet_handlers =
 {

--- a/server/server.cc
+++ b/server/server.cc
@@ -1,6 +1,6 @@
 /* server.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 27 Feb 2018, 07:54:23 tquirk
+ *   last updated 19 Apr 2018, 07:36:27 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -95,7 +95,7 @@ static void cleanup_sockets(void);
 static void cleanup_log(void);
 static void cleanup_daemon(void);
 
-int main_loop_exit_flag = 0;
+std::atomic<int> main_loop_exit_flag(0);
 Zone *zone = NULL;
 ActionPool *action_pool = NULL;   /* Takes action requests      */
 MotionPool *motion_pool = NULL;   /* Processes motion/collision */

--- a/server/server.h
+++ b/server/server.h
@@ -1,9 +1,9 @@
 /* server.h
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 20 Jun 2017, 19:56:48 tquirk
+ *   last updated 19 Apr 2018, 07:33:27 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2017  Trinity Annabelle Quirk
+ * Copyright (C) 2018  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -29,6 +29,8 @@
 #ifndef __INC_SERVER_H__
 #define __INC_SERVER_H__
 
+#include <atomic>
+
 #include "classes/zone.h"
 #include "classes/action_pool.h"
 #include "classes/motion_pool.h"
@@ -40,6 +42,7 @@ extern DB *database;
 extern ActionPool *action_pool;
 extern MotionPool *motion_pool;
 extern UpdatePool *update_pool;
+extern std::atomic<int> main_loop_exit_flag;
 
 void set_exit_flag(void);
 void complete_startup(void);


### PR DESCRIPTION
Removes all instances of the volatile keyword, in favor of std::atomic.

Resolves issue #201.