### PR TITLE
Import latest CuddlyGL changes

### DIFF
--- a/client/client.cc
+++ b/client/client.cc
@@ -1,6 +1,6 @@
 /* client.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 17 Jul 2019, 08:36:48 tquirk
+ *   last updated 06 Oct 2019, 08:22:07 tquirk
  *
  * Revision IX game client
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -102,13 +102,18 @@ int main(int argc, char **argv)
     }
 
     glfwMakeContextCurrent(w);
-    ctx = new ui::context(800, 600);
+    ctx = new ui::context(ui::element::size,
+                          ui::size::all,
+                          glm::ivec2(800, 600));
     ui_connect_glfw(ctx, w);
     ctx->add_callback(ui::callback::key_down, close_key_callback, NULL);
     ctx->add_callback(ui::callback::key_down, move_key_callback, NULL);
     ctx->add_callback(ui::callback::key_up, move_key_callback, NULL);
 
-    log_disp = new log_display(ctx, 0, 0);
+    log_disp = new log_display(ctx,
+                               ui::element::position,
+                               ui::position::all,
+                               glm::ivec2(10, -10));
     init_client_core();
 
     glfwSetWindowSizeCallback(w, resize_callback);

--- a/client/comm_dialog.cc
+++ b/client/comm_dialog.cc
@@ -1,6 +1,6 @@
 /* comm_dialog.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 17 Jul 2019, 08:40:50 tquirk
+ *   last updated 06 Oct 2019, 15:48:34 tquirk
  *
  * Revision IX game client
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -61,57 +61,65 @@ void create_login_dialog(ui::context *ctx)
 
     dialog_font = new ui::font(config.font_name, 10, config.font_paths);
 
-    dialog = new ui::row_column(ctx, 0, 0);
-    dialog->set(ui::element::border, ui::side::all, border,
-                ui::element::order, 0, ui::order::row,
-                ui::element::child_spacing, ui::size::width, 10,
-                ui::element::child_spacing, ui::size::height, 10,
-                ui::element::size, ui::size::columns, 2);
+    dialog = new ui::row_column(ctx,
+                                ui::element::border, ui::side::all, border,
+                                ui::element::order, 0, ui::order::row,
+                                ui::element::child_spacing, ui::size::width, 10,
+                                ui::element::child_spacing,
+                                ui::size::height,
+                                10,
+                                ui::element::size, ui::size::columns, 2);
 
-    l = new ui::label(dialog, 0, 0);
     str = _("Username");
-    l->set(ui::element::font, ui::ownership::shared, dialog_font,
-           ui::element::string, 0, str);
-    user = new ui::text_field(dialog, 0, 0);
+    l = new ui::label(dialog,
+                      ui::element::font, ui::ownership::shared, dialog_font,
+                      ui::element::string, 0, str);
     str = config.username;
-    user->set(ui::element::font, ui::ownership::shared, dialog_font,
-              ui::element::size, ui::size::max_width, max_sz,
-              ui::element::border, ui::side::all, border,
-              ui::element::string, 0, str);
+    user = new ui::text_field(dialog,
+                              ui::element::font,
+                              ui::ownership::shared,
+                              dialog_font,
+                              ui::element::size, ui::size::max_width, max_sz,
+                              ui::element::border, ui::side::all, border,
+                              ui::element::string, 0, str);
 
-    l = new ui::label(dialog, 0, 0);
     str = _("Password");
-    l->set(ui::element::font, ui::ownership::shared, dialog_font,
-           ui::element::string, 0, str);
-    pass = new ui::password(dialog, 0, 0);
-    pass->set(ui::element::font, ui::ownership::shared, dialog_font,
-              ui::element::size, ui::size::max_width, max_sz,
-              ui::element::border, ui::side::all, border);
+    l = new ui::label(dialog,
+                      ui::element::font, ui::ownership::shared, dialog_font,
+                      ui::element::string, 0, str);
+    pass = new ui::password(dialog,
+                            ui::element::font,
+                            ui::ownership::shared,
+                            dialog_font,
+                            ui::element::size, ui::size::max_width, max_sz,
+                            ui::element::border, ui::side::all, border);
 
-    l = new ui::label(dialog, 0, 0);
     str = _("Server");
-    l->set(ui::element::font, ui::ownership::shared, dialog_font,
-           ui::element::string, 0, str);
-    host = new ui::text_field(dialog, 0, 0);
+    l = new ui::label(dialog,
+                      ui::element::font, ui::ownership::shared, dialog_font,
+                      ui::element::string, 0, str);
     str = config.server_addr;
-    host->set(ui::element::font, ui::ownership::shared, dialog_font,
-              ui::element::size, ui::size::max_width, max_sz,
-              ui::element::border, ui::side::all, border,
-              ui::element::string, 0, str);
+    host = new ui::text_field(dialog,
+                              ui::element::font,
+                              ui::ownership::shared,
+                              dialog_font,
+                              ui::element::size, ui::size::max_width, max_sz,
+                              ui::element::border, ui::side::all, border,
+                              ui::element::string, 0, str);
 
-    b = new ui::button(dialog, 0, 0);
     str = _("OK");
-    b->set(ui::element::font, ui::ownership::shared, dialog_font,
-           ui::element::border, ui::side::all, border,
-           ui::element::string, 0, str);
+    b = new ui::button(dialog,
+                       ui::element::font, ui::ownership::shared, dialog_font,
+                       ui::element::border, ui::side::all, border,
+                       ui::element::string, 0, str);
     b->add_callback(ui::callback::btn_up, setup_comm_callback, NULL);
     b->add_callback(ui::callback::btn_up, close_dialog_callback, dialog);
 
-    b = new ui::button(dialog, 0, 0);
     str = _("Cancel");
-    b->set(ui::element::font, ui::ownership::shared, dialog_font,
-           ui::element::border, ui::side::all, border,
-           ui::element::string, 0, str);
+    b = new ui::button(dialog,
+                       ui::element::font, ui::ownership::shared, dialog_font,
+                       ui::element::border, ui::side::all, border,
+                       ui::element::string, 0, str);
     b->add_callback(ui::callback::btn_up, close_dialog_callback, dialog);
 
     dialog->manage_children();
@@ -153,7 +161,7 @@ void setup_comm_callback(ui::active *t, void *call, void *client)
 
 void close_dialog_callback(ui::active *t, void *call, void *client)
 {
-    ui::manager *dialog = (ui::manager *)client;
+    ui::row_column *dialog = (ui::row_column *)client;
 
     dialog->close();
     delete dialog_font;

--- a/client/log_display.h
+++ b/client/log_display.h
@@ -1,6 +1,6 @@
 /* log_display.h                                           -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 11 Nov 2018, 10:24:29 tquirk
+ *   last updated 06 Oct 2019, 08:24:13 tquirk
  *
  * Revision IX game client
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -69,6 +69,8 @@ class log_display : public ui::row_column,
     entry;
     typedef std::deque<entry>::iterator ld_iter;
 
+    static const int ENTRY_LIFETIME;
+
   protected:
     std::deque<entry> entries;
     std::deque<entry>::iterator created;
@@ -84,8 +86,18 @@ class log_display : public ui::row_column,
     void create_log_labels(void);
     static void *cleanup_entries(void *);
 
+    void init(void);
+
   public:
-    log_display(ui::composite *, GLuint, GLuint);
+    explicit log_display(ui::composite *);
+    template<typename... Args>
+    log_display(ui::composite *c, Args... args)
+        : ui::rect(0, 0), ui::active(0, 0), ui::row_column(c),
+          buf(), fname(), entries(), entry_lifetime(ENTRY_LIFETIME)
+        {
+            this->init();
+            this->set(args...);
+        };
     virtual ~log_display();
 
     virtual void draw(GLuint, const glm::mat4&) override;
@@ -93,8 +105,6 @@ class log_display : public ui::row_column,
   protected:
     int sync(void) override;
     int overflow(int) override;
-
-    static void resize_pos_callback(ui::active *, void *, void *);
 };
 
 #endif /* __INC_R9CLIENT_LOG_DISPLAY_H__ */


### PR DESCRIPTION
There have been significant changes to the CuddlyGL codebase over
the last while, which cascade down into a lot of our client code.
All constructors now have varargs formats, and the canned x/y
sizes are gone.  We can combine all of the constructor calls with
the set calls that usually follow.

Recently, the facility for setting negative positions has been
added, which removes the need for a lot of our log_display's custom
(and not-fully-functional) positioning code.

We had a couple of defines in the log_display, one of which we were
able to remove entirely due to the negative offset changes.  We
converted the other to a const class variable.