### PR TITLE
Install protocol headers

### DIFF
--- a/proto/Makefile.am
+++ b/proto/Makefile.am
@@ -1,11 +1,9 @@
 lib_LTLIBRARIES = libr9_proto.la
 
-libr9_proto_la_SOURCES = byteswap.c byteswap.h \
-	dh.c dh.h \
-	ec.c ec.h \
-	encrypt.c encrypt.h \
-	key.c key.h \
-	proto.h
+r9protodir = $(includedir)/r9
+r9proto_HEADERS = byteswap.h dh.h ec.h encrypt.h key.h proto.h
+
+libr9_proto_la_SOURCES = byteswap.c dh.c ec.c encrypt.c key.c
 
 clean-local:
 	rm -f *.gcno *.gcda *.gcov


### PR DESCRIPTION
Since the protocol library is a library, and people will need to
know how to interface with it, we need to install the headers.
We'll install them so something like '#include <r9/proto.h>' will
work.