### PR TITLE
Server library rework

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,7 +26,7 @@ AM_GNU_GETTEXT_VERSION(0.17)
 AC_LANG(C++)
 
 # Libtool init
-LT_INIT([pic-only])
+LT_INIT([pic-only disable-static])
 LT_LANG([C++])
 LT_SYS_MODULE_EXT
 

--- a/server/classes/Makefile.am
+++ b/server/classes/Makefile.am
@@ -1,5 +1,7 @@
 SUBDIRS = actions modules
 
+serverlibdir = $(pkglibdir)/server
+
 lib_LTLIBRARIES = libr9_classes.la
 
 libr9_classes_la_SOURCES = action.h action_pool.cc action_pool.h \
@@ -20,6 +22,7 @@ libr9_classes_la_SOURCES = action.h action_pool.cc action_pool.h \
 	zone.cc zone.h \
 	thread_pool.h
 libr9_classes_la_CXXFLAGS = -DSERVER_ROOT_DIR=\"$(prefix)\" \
+	-DSERVER_LIB_DIR=\"$(serverlibdir)\" \
 	-DSERVER_PID_FNAME=\"$(localstatedir)/run/r9.pid\"
 libr9_classes_la_LIBADD = ../../proto/libr9_proto.la
 

--- a/server/classes/Makefile.am
+++ b/server/classes/Makefile.am
@@ -1,6 +1,7 @@
 SUBDIRS = actions modules
 
 serverlibdir = $(pkglibdir)/server
+actionlibdir = $(serverlibdir)/actions
 
 lib_LTLIBRARIES = libr9_classes.la
 
@@ -23,6 +24,7 @@ libr9_classes_la_SOURCES = action.h action_pool.cc action_pool.h \
 	thread_pool.h
 libr9_classes_la_CXXFLAGS = -DSERVER_ROOT_DIR=\"$(prefix)\" \
 	-DSERVER_LIB_DIR=\"$(serverlibdir)\" \
+	-DACTION_LIB_DIR=\"$(actionlibdir)\" \
 	-DSERVER_PID_FNAME=\"$(localstatedir)/run/r9.pid\"
 libr9_classes_la_LIBADD = ../../proto/libr9_proto.la
 

--- a/server/classes/action_pool.h
+++ b/server/classes/action_pool.h
@@ -1,9 +1,9 @@
 /* action_pool.h                                           -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Dec 2019, 13:57:14 tquirk
+ *   last updated 24 Dec 2020, 15:28:52 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -30,6 +30,8 @@
 #ifndef __INC_ACTION_POOL_H__
 #define __INC_ACTION_POOL_H__
 
+#include <vector>
+
 #include "../../proto/proto.h"
 #include "thread_pool.h"
 #include "library.h"
@@ -41,7 +43,7 @@
 class ActionPool : public ThreadPool<packet_list>
 {
   private:
-    Library *action_lib;
+    std::vector<Library *> action_libs;
 
     actions_map actions;
 
@@ -50,7 +52,7 @@ class ActionPool : public ThreadPool<packet_list>
     void load_actions(void);
 
   public:
-    ActionPool(unsigned int, GameObject::objects_map&, Library *, DB *);
+    ActionPool(unsigned int, GameObject::objects_map&, DB *);
     ~ActionPool();
 
     void start(void);

--- a/server/classes/actions/Makefile.am
+++ b/server/classes/actions/Makefile.am
@@ -1,7 +1,11 @@
-lib_LTLIBRARIES = libr9_actions.la
+action_libs = libr9_actions.la
+
+actionlibdir = $(pkglibdir)/server/actions
+
+actionlib_LTLIBRARIES = $(action_libs)
 
 libr9_actions_la_SOURCES = register.cc control_object.cc move.cc register.h
-libr9_actions_la_LDFLAGS = -module
+libr9_actions_la_LDFLAGS = -module -avoid-version
 
 clean-local:
 	rm -f *.gcno *.gcda *.gcov

--- a/server/classes/actions/Makefile.am
+++ b/server/classes/actions/Makefile.am
@@ -7,5 +7,8 @@ actionlib_LTLIBRARIES = $(action_libs)
 libr9_actions_la_SOURCES = register.cc control_object.cc move.cc register.h
 libr9_actions_la_LDFLAGS = -module -avoid-version
 
+install-data-hook:
+	cd $(actionlibdir) && rm -f $(action_libs)
+
 clean-local:
 	rm -f *.gcno *.gcda *.gcov

--- a/server/classes/config_data.cc
+++ b/server/classes/config_data.cc
@@ -1,9 +1,9 @@
 /* config_data.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 16 Sep 2019, 08:27:08 tquirk
+ *   last updated 13 Dec 2020, 22:02:36 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -25,7 +25,6 @@
  *
  * Current configuration options include:
  *   AccessThreads <num>    number of access threads to start
- *   ActionLib <libname>    name of library which contains the action routines
  *   ActionThreads <num>    number of action threads to start
  *   Console <port type>    port specification for a console listener
  *   DBDatabase <dbname>    the name of the database to use
@@ -114,7 +113,6 @@ const char config_data::PID_FNAME[]   = SERVER_PID_FNAME;
 const char config_data::DB_TYPE[]     = "MySQL";
 const char config_data::DB_HOST[]     = "localhost";
 const char config_data::DB_NAME[]     = "r9";
-const char config_data::ACTION_LIB[]  = "libr9_actions" LT_MODULE_EXT;
 
 typedef void (*config_elem_t)(const std::string&, const std::string&, void *);
 
@@ -142,7 +140,6 @@ handlers[] =
 {
 #define off(x)  (void *)(&(config.x))
     { "AccessThreads", off(access_threads), &config_integer_element  },
-    { "ActionLib",     off(action_lib),     &config_string_element   },
     { "ActionThreads", off(action_threads), &config_integer_element  },
     { "Console",       off(consoles),       &config_port_element     },
     { "DBDatabase",    off(db_name),        &config_string_element   },
@@ -186,8 +183,7 @@ config_data::config_data()
       server_root(config_data::SERVER_ROOT),
       log_prefix(config_data::LOG_PREFIX), pid_fname(config_data::PID_FNAME),
       db_type(config_data::DB_TYPE), db_host(config_data::DB_HOST),
-      db_user(), db_pass(), db_name(config_data::DB_NAME),
-      action_lib(config_data::ACTION_LIB)
+      db_user(), db_pass(), db_name(config_data::DB_NAME)
 {
     this->set_defaults();
 }
@@ -211,7 +207,6 @@ void config_data::set_defaults(void)
     this->db_user        = "";
     this->db_pass        = "";
     this->db_name        = config_data::DB_NAME;
-    this->action_lib     = config_data::ACTION_LIB;
 
     this->daemonize      = true;
     this->use_keepalive  = false;

--- a/server/classes/config_data.h
+++ b/server/classes/config_data.h
@@ -1,9 +1,9 @@
 /* config_data.h                                           -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 06 Jun 2019, 08:10:02 tquirk
+ *   last updated 13 Dec 2020, 21:59:51 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -81,7 +81,6 @@ class config_data
     static const char DB_TYPE[];
     static const char DB_HOST[];
     static const char DB_NAME[];
-    static const char ACTION_LIB[];
 
     std::vector<std::string> argv;
     std::vector<port> listen_ports, consoles;

--- a/server/classes/library.cc
+++ b/server/classes/library.cc
@@ -1,6 +1,6 @@
 /* library.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 26 Dec 2020, 22:42:01 tquirk
+ *   last updated 27 Dec 2020, 14:14:59 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2020  Trinity Annabelle Quirk
@@ -56,6 +56,8 @@ void Library::open(void)
 {
     char *err;
 
+    if (this->libname[0] != '/')
+        this->libname.insert(0, std::string(SERVER_LIB_DIR) + "/");
     this->lib = dlopen(this->libname.c_str(), RTLD_LAZY | RTLD_GLOBAL);
     if ((err = dlerror()) != NULL)
     {

--- a/server/classes/library.h
+++ b/server/classes/library.h
@@ -1,9 +1,9 @@
 /* library.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 17 Mar 2018, 08:17:21 tquirk
+ *   last updated 24 Dec 2020, 15:39:02 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2018  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -30,6 +30,7 @@
 #define __INC_LIBRARY_H__
 
 #include <string>
+#include <vector>
 
 class Library
 {
@@ -48,5 +49,7 @@ class Library
     virtual void *symbol(const char *);
     virtual void close(void);
 };
+
+void find_libraries(const std::string&, std::vector<Library *>&);
 
 #endif /* __INC_LIBRARY_H__ */

--- a/server/classes/modules/Makefile.am
+++ b/server/classes/modules/Makefile.am
@@ -45,5 +45,8 @@ libr9_tcl_la_SOURCES = r9tcl.cc r9tcl.h language.cc language.h
 libr9_tcl_la_CXXFLAGS = $(TCL_INCLUDES)
 libr9_tcl_la_LIBADD = $(TCL_LDLIBS)
 
+install-data-hook:
+	cd $(serverlibdir) && rm -f $(modules_libs)
+
 clean-local:
 	rm -f *.gcno *.gcda *.gcov

--- a/server/classes/modules/Makefile.am
+++ b/server/classes/modules/Makefile.am
@@ -15,8 +15,11 @@ if WANT_TCL
 modules_libs += libr9_tcl.la
 endif
 
-lib_LTLIBRARIES = $(modules_libs)
-AM_LDFLAGS = -module
+serverlibdir = $(pkglibdir)/server
+
+serverlib_LTLIBRARIES = $(modules_libs)
+
+AM_LDFLAGS = -module -avoid-version
 
 libr9_console_la_SOURCES = console.cc console.h ../basesock.cc ../basesock.h \
 	fdstreambuf.h
@@ -36,7 +39,7 @@ libr9_lua_la_LIBADD = $(LUA_LDLIBS)
 
 libr9_python_la_SOURCES = r9python.cc r9python.h language.cc language.h
 libr9_python_la_CXXFLAGS = $(PYTHON_CFLAGS)
-libr9_python_la_LDFLAGS = -module $(PYTHON_LDFLAGS)
+libr9_python_la_LDFLAGS = $(AM_LDFLAGS) $(PYTHON_LDFLAGS)
 
 libr9_tcl_la_SOURCES = r9tcl.cc r9tcl.h language.cc language.h
 libr9_tcl_la_CXXFLAGS = $(TCL_INCLUDES)

--- a/server/server.cc
+++ b/server/server.cc
@@ -1,9 +1,9 @@
 /* server.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 16 Sep 2019, 07:57:25 tquirk
+ *   last updated 13 Dec 2020, 21:38:31 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -359,14 +359,8 @@ static void setup_thread_pools(void)
      */
     motion_pool = new MotionPool("motion", config.motion_threads);
     update_pool = new UpdatePool("update", config.update_threads);
-
-    /* Once this library gets into the hands of the action pool, it
-     * takes ownership, and cleans it up where necessary.
-     */
-    Library *action_lib = new Library(config.action_lib);
     action_pool = new ActionPool(config.action_threads,
                                  zone->game_objects,
-                                 action_lib,
                                  database);
 
     action_pool->start();

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -62,6 +62,7 @@ CONFIG_DEFS = -DSERVER_ROOT_DIR=\"./\" -DSERVER_PID_FNAME=\"blah.pid\"
 if HAVE_LIBWRAP
   CONFIG_DEFS += -DHAVE_LIBWRAP=1
 endif
+LIBDIR_DEFS = -DSERVER_LIB_DIR=\".\"
 
 t_byteswap_SOURCES = t_byteswap.cc ../proto/byteswap.c ../proto/proto.h
 t_byteswap_LDADD = $(TAP_LDADD) ../proto/libr9_proto.la
@@ -145,6 +146,7 @@ t_game_obj_LDADD = $(TAP_LDADD)
 
 t_library_SOURCES = t_library.cc \
 	../server/classes/library.cc ../server/classes/library.h
+t_library_CXXFLAGS = $(CONFIG_DEFS) $(LIBDIR_DEFS) $(TAP_INCLUDES)
 t_library_LDADD = $(TAP_LDADD) $(SERVER_LDLIBS)
 
 t_listensock_SOURCES = t_listensock.cc \
@@ -227,19 +229,22 @@ t_zone_LDADD = $(TAP_LDADD) \
 
 t_lua_SOURCES = t_lua.cc ../server/classes/modules/language.h \
 	../server/classes/library.h ../server/classes/library.cc
+t_lua_CXXFLAGS = $(LIBDIR_DEFS) $(TAP_INCLUDES)
 t_lua_LDADD = $(TAP_LDADD) $(SERVER_LDLIBS)
 
 t_python_SOURCES = t_python.cc ../server/classes/modules/language.h \
 	../server/classes/library.h ../server/classes/library.cc
+t_python_CXXFLAGS = $(LIBDIR_DEFS) $(TAP_INCLUDES)
 t_python_LDADD = $(TAP_LDADD) $(SERVER_LDLIBS)
 
 t_tcl_SOURCES = t_tcl.cc ../server/classes/modules/language.h \
 	../server/classes/library.h ../server/classes/library.cc
+t_tcl_CXXFLAGS = $(LIBDIR_DEFS) $(TAP_INCLUDES)
 t_tcl_LDADD = $(TAP_LDADD) $(SERVER_LDLIBS)
 
 t_tcl_exception_SOURCES = t_tcl_exception.cc \
 	../server/classes/modules/r9tcl.cc ../server/classes/modules/r9tcl.h
-t_tcl_exception_CXXFLAGS = $(TAP_INCLUDES) $(TCL_INCLUDES)
+t_tcl_exception_CXXFLAGS = $(LIBDIR_DEFS) $(TAP_INCLUDES) $(TCL_INCLUDES)
 t_tcl_exception_LDADD = $(TAP_LDADD) $(SERVER_LDLIBS) \
 	$(TCL_LDLIBS)
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -62,7 +62,7 @@ CONFIG_DEFS = -DSERVER_ROOT_DIR=\"./\" -DSERVER_PID_FNAME=\"blah.pid\"
 if HAVE_LIBWRAP
   CONFIG_DEFS += -DHAVE_LIBWRAP=1
 endif
-LIBDIR_DEFS = -DSERVER_LIB_DIR=\".\"
+LIBDIR_DEFS = -DSERVER_LIB_DIR=\".\" -DACTION_LIB_DIR=\".\"
 
 t_byteswap_SOURCES = t_byteswap.cc ../proto/byteswap.c ../proto/proto.h
 t_byteswap_LDADD = $(TAP_LDADD) ../proto/libr9_proto.la
@@ -85,7 +85,7 @@ t_key_LDADD = $(TAP_LDADD) ../proto/libr9_proto.la
 t_action_pool_SOURCES = t_action_pool.cc \
 	../server/classes/action_pool.cc ../server/classes/action_pool.h \
 	../server/classes/modules/db.cc ../server/classes/modules/db.h
-t_action_pool_CXXFLAGS = $(CONFIG_DEFS) $(TAP_INCLUDES)
+t_action_pool_CXXFLAGS = $(CONFIG_DEFS) $(LIBDIR_DEFS) $(TAP_INCLUDES)
 t_action_pool_LDADD = $(TAP_LDADD) \
 	../proto/libr9_proto.la ../server/classes/libr9_classes.la \
 	$(SERVER_LDLIBS)

--- a/test/t_action_pool.cc
+++ b/test/t_action_pool.cc
@@ -11,11 +11,11 @@ using namespace TAP;
 #include "mock_server_globals.h"
 #include "mock_zone.h"
 
+
 void register_actions(actions_map&);
 void unregister_actions(actions_map&);
 int fake_action(GameObject *, int, GameObject *, glm::dvec3&);
 
-fake_Library *lib;
 GameObject::objects_map *game_objs;
 fake_listen_socket *listensock;
 int register_count, unregister_count, action_count;
@@ -46,15 +46,14 @@ int fake_action(GameObject *a, int b, GameObject *c, glm::dvec3& d)
     return 4;
 }
 
+void find_libraries(const std::string& a, std::vector<Library *>& b)
+{
+    b.push_back(new fake_Library("whatever"));
+}
+
 void setup_fixture(void)
 {
     database = new fake_DB("a", "b", "c", "d");
-
-    /* The action pool takes control of this library, and
-     * deletes it when the pool is destroyed.  We don't need
-     * to delete it ourselves.
-     */
-    lib = new fake_Library("doesn't matter");
 
     symbol_count = 0;
     symbol_result = (void *)register_actions;
@@ -90,7 +89,7 @@ void test_create_delete(void)
 
     try
     {
-        action_pool = new ActionPool(1, *game_objs, lib, database);
+        action_pool = new ActionPool(1, *game_objs, database);
     }
     catch (...)
     {
@@ -113,7 +112,7 @@ void test_start_stop(void)
 
     setup_fixture();
 
-    action_pool = new ActionPool(1, *game_objs, lib, database);
+    action_pool = new ActionPool(1, *game_objs, database);
     action_pool->start();
     is(action_pool->startup_arg == action_pool, true,
        test + "expected startup arg");
@@ -138,7 +137,7 @@ void test_no_skill(void)
     get_character_objectid_result = 9876LL;
     base_user *bu = new base_user(123LL, "a", "b", listensock);
 
-    action_pool = new ActionPool(1, *game_objs, lib, database);
+    action_pool = new ActionPool(1, *game_objs, database);
 
     action_request pkt;
     memset(&pkt, 0, sizeof(action_request));
@@ -174,7 +173,7 @@ void test_invalid_skill(void)
     base_user *bu = new base_user(123LL, "a", "b", listensock);
     bu->actions[567] = {567, 5, 0, 0};
 
-    action_pool = new ActionPool(1, *game_objs, lib, database);
+    action_pool = new ActionPool(1, *game_objs, database);
 
     action_request pkt;
     memset(&pkt, 0, sizeof(action_request));
@@ -210,7 +209,7 @@ void test_wrong_object_id(void)
     base_user *bu = new base_user(123LL, "a", "b", listensock);
     bu->actions[789] = {789, 5, 0, 0};
 
-    action_pool = new ActionPool(1, *game_objs, lib, database);
+    action_pool = new ActionPool(1, *game_objs, database);
 
     action_request pkt;
     memset(&pkt, 0, sizeof(action_request));
@@ -246,7 +245,7 @@ void test_good_object_id(void)
     base_user *bu = new base_user(123LL, "a", "b", listensock);
     bu->actions[789] = {789, 5, 0, 0};
 
-    action_pool = new ActionPool(1, *game_objs, lib, database);
+    action_pool = new ActionPool(1, *game_objs, database);
 
     action_request pkt;
     memset(&pkt, 0, sizeof(action_request));
@@ -282,7 +281,7 @@ void test_worker(void)
     base_user *bu = new base_user(123LL, "a", "b", listensock);
     bu->actions[789] = {789, 5, 0, 0};
 
-    action_pool = new ActionPool(1, *game_objs, lib, database);
+    action_pool = new ActionPool(1, *game_objs, database);
 
     packet_list pl;
     memset(&pl.buf, 0, sizeof(action_request));

--- a/test/t_config_data.cc
+++ b/test/t_config_data.cc
@@ -94,7 +94,6 @@ void test_create_delete(void)
     is(conf->db_type, config_data::DB_TYPE, test + "expected db type");
     is(conf->db_host, config_data::DB_HOST, test + "expected db host");
     is(conf->db_name, config_data::DB_NAME, test + "expected db name");
-    is(conf->action_lib, config_data::ACTION_LIB, test + "expected action lib");
     is(conf->daemonize, true, test + "expected daemonize");
     is(conf->use_keepalive, false, test + "expected keepalive");
     is(conf->use_nonblock, false, test + "expected nonblock");
@@ -344,7 +343,7 @@ void test_parse_config_file(void)
 
 int main(int argc, char **argv)
 {
-    plan(85);
+    plan(84);
 
     test_create_delete();
     test_setup_cleanup();

--- a/test/t_library.cc
+++ b/test/t_library.cc
@@ -26,10 +26,7 @@ extern "C" {
 
     void *dlopen(const char *a, int b)
     {
-        if (strcmp(a, good_lib))
-            return NULL;
-        /* Doesn't matter what we return, as long as it's not NULL */
-        return (void *)good_lib;
+        return (void *)strstr(a, good_lib);
     }
 
     int dlclose(void *a)
@@ -140,10 +137,29 @@ void test_good_constructor(void)
     delete lib1;
 }
 
+void test_pathed_constructor(void)
+{
+    std::string test = "constructor w/path: ";
+    Library *lib1 = NULL;
+    try
+    {
+        std::string libname("/foo/bar/");
+        libname += good_lib;
+        lib1 = new Library(libname);
+    }
+    catch (...)
+    {
+        fail(test + "constructor exception");
+    }
+    ok(lib1 != NULL, test + "library created");
+    delete lib1;
+}
+
 void test_missing_symbol(void)
 {
     std::string test = "symbol failure: ";
     Library *lib1 = NULL;
+    error_fail = false;
     try
     {
         std::string libname = good_lib;
@@ -158,6 +174,7 @@ void test_missing_symbol(void)
     try
     {
         lib1->symbol("symbol that doesn't exist");
+        fail(test + "actually found symbol");
     }
     catch (std::runtime_error& e)
     {
@@ -179,6 +196,7 @@ void test_good_symbol(void)
     std::string test = "symbol: ";
     Library *lib1 = NULL;
 
+    error_fail = false;
     try
     {
         std::string libname = good_lib;
@@ -338,11 +356,12 @@ void test_find_libraries(void)
 
 int main(int argc, char **argv)
 {
-    plan(22);
+    plan(23);
 
     test_default_constructor();
     test_bad_constructor();
     test_good_constructor();
+    test_pathed_constructor();
     test_missing_symbol();
     test_good_symbol();
     test_bad_close();


### PR DESCRIPTION
Move the install path of action and module library files out of the main system library path.  Also enable an arbitrary number of action libraries, instead of forcing only one.