### PR TITLE
Add lcov target to main Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ test-driver
 
 # Xcode
 *.xcodeproj/
+
+lcov.info
+lcov/

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,3 +24,15 @@ all-local:
 endif
 
 install-recursive: SUBDIRS = $(SD_NO_TEST)
+
+if HAVE_LCOV
+.PHONY: lcov
+
+lcov: check
+	lcov -c -q --directory . --output-file lcov.info --no-external
+	genhtml lcov.info --output-directory lcov
+	@echo "Open file://$$PWD/lcov/index.html in your browser"
+
+clean-local:
+	rm -rf lcov.info lcov
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -179,6 +179,9 @@ then
     PROFILE_LDLIBS="-lgcov"
     AC_MSG_NOTICE([building with profiling enabled])
   fi
+  AC_CHECK_PROGS([lcov_cmd], [lcov])
+  AC_CHECK_PROGS([genhtml_cmd], [genhtml])
+  AM_CONDITIONAL([HAVE_LCOV], [test "x$lcov_cmd" != "x" && test "x$genhtml_cmd" != "x"])
 fi
 
 # Client program


### PR DESCRIPTION
Having a decent local profiling capability is better than relying on an external service (which is starting to become a pain to use).  `lcov` isn't the greatest thing out there (branch detection on C++ is notoriously bad), but it works, and there's a nice HTML report.