### PR TITLE
Deactivated movement

### DIFF
--- a/server/classes/game_obj.cc
+++ b/server/classes/game_obj.cc
@@ -1,9 +1,9 @@
 /* game_obj.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 14 Nov 2020, 13:32:11 tquirk
+ *   last updated 02 Mar 2021, 09:07:21 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -75,6 +75,7 @@ GameObject::GameObject(Geometry *g, Control *c, uint64_t newid)
 {
     this->default_master = this->master = c;
     this->default_geometry = this->geometry = g;
+    this->active = true;
     pthread_mutex_lock(&GameObject::max_mutex);
     if (newid == 0LL)
         newid = GameObject::max_id_value++;
@@ -156,6 +157,7 @@ void GameObject::activate(void)
     this->enter();
     this->natures.erase(GameObject::nature::invisible);
     this->natures.erase(GameObject::nature::non_interactive);
+    this->active = true;
     this->leave();
 }
 
@@ -171,6 +173,7 @@ void GameObject::deactivate(void)
     this->rotation = GameObject::no_rotation;
     this->natures.insert(GameObject::nature::invisible);
     this->natures.insert(GameObject::nature::non_interactive);
+    this->active = false;
     this->leave();
 }
 
@@ -293,8 +296,9 @@ void GameObject::move_and_rotate(void)
 bool GameObject::still_moving(void)
 {
     this->enter_read();
-    bool res = (this->movement != GameObject::no_movement
-                || this->rotation != GameObject::no_rotation);
+    bool res = (this->active == true
+                && (this->movement != GameObject::no_movement
+                    || this->rotation != GameObject::no_rotation));
     this->leave();
     return res;
 }

--- a/server/classes/game_obj.h
+++ b/server/classes/game_obj.h
@@ -1,9 +1,9 @@
 /* game_obj.h                                              -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 03 Nov 2020, 07:06:49 tquirk
+ *   last updated 02 Mar 2021, 09:04:26 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -81,6 +81,8 @@ class GameObject
     struct timeval last_updated;
     glm::dvec3 position, movement, look;
     glm::dquat orient, rotation;
+
+    bool active;
 
   public:
     std::unordered_map<std::string, attribute> attributes;

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -1,9 +1,9 @@
 /* listensock.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 11 Jan 2020, 22:20:20 tquirk
+ *   last updated 03 Mar 2021, 08:59:25 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -484,6 +484,8 @@ void listen_socket::logout_user(uint64_t userid)
 
         bu->send_ack(TYPE_LGTREQ);
         bu->pending_logout = true;
+        if (bu->default_slave != NULL)
+            bu->default_slave->deactivate();
     }
 }
 
@@ -493,7 +495,10 @@ void listen_socket::connect_user(base_user *bu, access_list& al)
 
     this->users[bu->userid] = bu;
     if (bu->default_slave != NULL)
+    {
+        bu->default_slave->activate();
         obj_id = bu->default_slave->get_object_id();
+    }
     bu->send_server_key(config.key.pub_key, R9_PUBKEY_SZ);
     bu->send_ack(TYPE_LOGREQ, bu->auth_level, obj_id);
 }

--- a/server/classes/motion_pool.cc
+++ b/server/classes/motion_pool.cc
@@ -1,6 +1,6 @@
 /* motion_pool.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 17 Oct 2020, 22:13:12 tquirk
+ *   last updated 06 Mar 2021, 16:30:25 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2020  Trinity Annabelle Quirk
@@ -73,17 +73,20 @@ void *MotionPool::motion_pool_worker(void *arg)
     {
         mot->pop(&req);
 
-        zone->sector_contains(req->get_position())->remove(req);
-        req->move_and_rotate();
-        sector = zone->sector_contains(req->get_position());
-        if (sector != NULL)
-            sector->insert(req);
-        /* else figure out the neighbor that it needs to go to */
-        /*mot->physics->collide(sector, req);*/
-        update_pool->push(req);
-
         if (req->still_moving())
-            mot->push(req);
+        {
+            zone->sector_contains(req->get_position())->remove(req);
+            req->move_and_rotate();
+            sector = zone->sector_contains(req->get_position());
+            if (sector != NULL)
+                sector->insert(req);
+            /* else figure out the neighbor that it needs to go to */
+            /*mot->physics->collide(sector, req);*/
+            update_pool->push(req);
+
+            if (req->still_moving())
+                mot->push(req);
+        }
     }
     return NULL;
 }

--- a/test/t_game_obj.cc
+++ b/test/t_game_obj.cc
@@ -1,3 +1,5 @@
+#include <unistd.h>
+
 #include <tap++.h>
 
 using namespace TAP;
@@ -242,7 +244,7 @@ void test_move_and_rotate(void)
     go->set_movement(glm::dvec3(1.0, 1.0, 1.0));
     go->set_rotation(glm::dquat(1.0, 0.0, 0.0, 1.0));
 
-    sleep(1);
+    usleep(100);
     go->move_and_rotate();
 
     ok(go->get_position() != glm::dvec3(0.0, 0.0, 0.0),
@@ -250,13 +252,23 @@ void test_move_and_rotate(void)
     ok(go->get_orientation() != glm::dquat(1.0, 0.0, 0.0, 0.0),
        test + "expected rotation");
 
+    go->deactivate();
+    glm::dvec3 pos = go->get_position();
+    glm::dquat ori = go->get_orientation();
+
+    usleep(100);
+    go->move_and_rotate();
+
+    ok(go->get_position() == pos, test + "expected inactive movement");
+    ok(go->get_orientation() == ori, test + "expected inactive rotation");
+
     delete go;
     delete con;
 }
 
 int main(int argc, char **argv)
 {
-    plan(52);
+    plan(54);
 
     test_create_delete();
     test_clone();

--- a/test/t_motion_pool.cc
+++ b/test/t_motion_pool.cc
@@ -59,15 +59,16 @@ void test_operate(void)
     motion_pool->push(go3);
     is(motion_pool->queue_size(), 3, test + "expected queue size");
     go4->set_position(glm::dvec3(0.0, 0.0, 0.0));
-    go4->set_rotation(glm::dquat(1.0, 0.0, 0.0, 0.0));
+    go4->set_rotation(glm::angleAxis(1.0, glm::dvec3(1.0, 0.0, 0.0)));
     motion_pool->push(go4);
-    is(motion_pool->queue_size(), 4, test + "expected queue sizer");
+    is(motion_pool->queue_size(), 4, test + "expected queue size");
     go5->set_position(glm::dvec3(1.0, 1.0, 1.0));
-    go5->set_rotation(glm::dquat(0.0, 1.0, 0.0, 0.0));
+    go5->set_rotation(glm::angleAxis(1.0, glm::dvec3(0.0, 1.0, 0.0)));
     motion_pool->push(go5);
     is(motion_pool->queue_size(), 5, test + "expected queue size");
     go6->set_position(glm::dvec3(2.0, 2.0, 2.0));
-    go6->set_rotation(glm::dquat(0.0, 0.0, 1.0, 0.0));
+    go6->set_movement(glm::dvec3(10.0, 0.0, 0.0));
+    go6->deactivate();
     motion_pool->push(go6);
     is(motion_pool->queue_size(), 6, test + "expected queue size");
 
@@ -76,15 +77,17 @@ void test_operate(void)
         ;
     motion_pool->stop();
 
-    is(go1->get_position().x > 234.0, true, test + "x pos increased");
-    is(go1->get_position().y > 234.0, true, test + "y pos increased");
-    is(go1->get_position().z > 234.0, true, test + "z pos increased");
-    is(go2->get_position().y > 123.0, true, test + "y pos increased");
-    is(go2->get_position().z > 123.0, true, test + "z pos increased");
-    is(go3->get_position().z > 12.0, true, test + "z pos increased");
-    /* Nothing happens with rotation yet, so no need to check anything
-     * for go4-6.
-     */
+    ok(go1->get_position().x > 234.0, test + "x pos increased");
+    ok(go1->get_position().y > 234.0, test + "y pos increased");
+    ok(go1->get_position().z > 234.0, test + "z pos increased");
+    ok(go2->get_position().y > 123.0, test + "y pos increased");
+    ok(go2->get_position().z > 123.0, test + "z pos increased");
+    ok(go3->get_position().z > 12.0, test + "z pos increased");
+    ok(glm::eulerAngles(go4->get_orientation()).x != 0.0,
+       test + "x rot changed");
+    ok(glm::eulerAngles(go5->get_orientation()).y != 0.0,
+       test + "y rot changed");
+    ok(go6->get_position().x == 2.0, test + "x pos stayed the same");
 
     delete update_pool;
     delete motion_pool;
@@ -96,7 +99,7 @@ void test_operate(void)
 
 int main(int argc, char **argv)
 {
-    plan(13);
+    plan(16);
 
     test_start_stop();
     test_operate();


### PR DESCRIPTION
We've had the concept of "deactivated" for a long time, but it hasn't meant anything.  It *should* mean that the object isn't really dealt with by motion pools.  This change makes that more of the truth.

We still need to tell the clients to delete their object when something gets deactivated, but that's going to be a bigger change.