### PR TITLE
Remove inactive objects

### DIFF
--- a/client/comm.cc
+++ b/client/comm.cc
@@ -1,9 +1,9 @@
 /* comm.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 06 Dec 2020, 14:53:48 tquirk
+ *   last updated 14 Mar 2021, 23:22:32 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -529,7 +529,7 @@ void Comm::send_login(const std::string& user,
 
     memset(req, 0, sizeof(packet));
     req->log.type = TYPE_LOGREQ;
-    req->log.version = 1;
+    req->log.version = R9_PROTO_VER;
     req->log.sequence = this->sequence++;
     strncpy(req->log.username, user.c_str(), sizeof(req->log.username));
     strncpy(req->log.charname, character.c_str(), sizeof(req->log.charname));
@@ -545,7 +545,7 @@ void Comm::send_action_request(uint16_t actionid,
 
     memset(req, 0, sizeof(packet));
     req->act.type = TYPE_ACTREQ;
-    req->act.version = 1;
+    req->act.version = R9_PROTO_VER;
     req->act.sequence = sequence++;
     req->act.object_id = this->src_object_id;
     req->act.action_id = actionid;
@@ -562,7 +562,7 @@ void Comm::send_action_request(uint16_t actionid,
 
     memset(req, 0, sizeof(packet));
     req->act.type = TYPE_ACTREQ;
-    req->act.version = 1;
+    req->act.version = R9_PROTO_VER;
     req->act.sequence = sequence++;
     req->act.object_id = this->src_object_id;
     req->act.action_id = actionid;
@@ -579,7 +579,7 @@ void Comm::send_logout(void)
 
     memset(req, 0, sizeof(packet));
     req->basic.type = TYPE_LGTREQ;
-    req->basic.version = 1;
+    req->basic.version = R9_PROTO_VER;
     req->basic.sequence = sequence++;
     this->send(req, sizeof(basic_packet));
 }
@@ -590,7 +590,7 @@ void Comm::send_ack(uint8_t type)
 
     memset(req, 0, sizeof(packet));
     req->ack.type = TYPE_ACKPKT;
-    req->ack.version = 1;
+    req->ack.version = R9_PROTO_VER;
     req->ack.sequence = sequence++;
     req->ack.request = type;
     this->send(req, sizeof(ack_packet));

--- a/proto/proto.h
+++ b/proto/proto.h
@@ -1,9 +1,9 @@
 /* proto.h
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 28 Sep 2020, 22:31:07 tquirk
+ *   last updated 13 Mar 2021, 08:03:03 tquirk
  *
  * Revision IX game protocol
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -44,6 +44,8 @@
  *   LGTREQ:  This packet is a user request to logout.
  *   SRVKEY:  This packet is a server login response which includes
  *            the server key.
+ *   OBJDEL:  This packet notifies a client that an object is no longer
+ *            present, and that the client should delete it.
  *
  * Things to do
  *   - Rethink the removal of in-band geometry and texture fetching.
@@ -65,6 +67,7 @@
 #define TYPE_PNGPKT 5        /* Ping packet */
 #define TYPE_LGTREQ 6        /* Logout request */
 #define TYPE_SRVKEY 7        /* Server key request */
+#define TYPE_OBJDEL 8        /* Object deletion */
 
 /* Access types for the login ACK's misc field.  Are there more types? */
 #define ACCESS_NONE 1        /* No access allowed */
@@ -173,6 +176,15 @@ typedef struct server_key_tag
 } __attribute__ ((__packed__))
 server_key;
 
+typedef struct object_delete_tag
+{
+    uint8_t type;
+    uint8_t version;        /* protocol version number */
+    uint64_t sequence;      /* timestamp / sequence number */
+    uint64_t object_id;
+} __attribute__ ((__packed__))
+object_delete;
+
 /* We can cast unknown packets to this and read basic.type to determine
  * the type, then use the corresponding element of the union to process it.
  * We don't need to convert byte order on a single byte, so this trick will
@@ -187,6 +199,7 @@ typedef union packet_tag
     position_update  pos;
     server_notice    srv;
     server_key       key;
+    object_delete    del;
 }
 packet;
 
@@ -201,6 +214,7 @@ packet;
 #define is_server_notice(x)    (((packet *)(x))->basic.type == TYPE_SRVNOT)
 #define is_ping_packet(x)      (((packet *)(x))->basic.type == TYPE_PNGPKT)
 #define is_server_key(x)       (((packet *)(x))->basic.type == TYPE_SRVKEY)
+#define is_object_delete(x)    (((packet *)(x))->basic.type == TYPE_OBJDEL)
 
 #ifdef __cplusplus
 extern "C"

--- a/proto/proto.h
+++ b/proto/proto.h
@@ -1,6 +1,6 @@
 /* proto.h
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 13 Mar 2021, 08:03:03 tquirk
+ *   last updated 14 Mar 2021, 23:26:22 tquirk
  *
  * Revision IX game protocol
  * Copyright (C) 2021  Trinity Annabelle Quirk
@@ -57,6 +57,9 @@
 
 #include <stdint.h>
 #include <arpa/inet.h>
+
+/* The protocol version which we support */
+#define R9_PROTO_VER 1
 
 /* Some defines for packet types. */
 #define TYPE_ACKPKT 0        /* Acknowledgement packet */

--- a/server/classes/game_obj.cc
+++ b/server/classes/game_obj.cc
@@ -1,6 +1,6 @@
 /* game_obj.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 02 Mar 2021, 09:07:21 tquirk
+ *   last updated 13 Mar 2021, 09:25:19 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2021  Trinity Annabelle Quirk
@@ -301,4 +301,36 @@ bool GameObject::still_moving(void)
                     || this->rotation != GameObject::no_rotation));
     this->leave();
     return res;
+}
+
+void GameObject::generate_update_packet(packet& pkt)
+{
+    this->enter_read();
+    if (this->active == false)
+    {
+        pkt.del.type = TYPE_OBJDEL;
+        pkt.del.version = 1;
+        pkt.del.object_id = this->id_value;
+    }
+    else
+    {
+        glm::dvec3 pos = this->position * POSUPD_POS_SCALE;
+        glm::dquat orient = this->orient * POSUPD_ORIENT_SCALE;
+        glm::dvec3 look = this->look * POSUPD_LOOK_SCALE;
+
+        pkt.pos.type = TYPE_POSUPD;
+        pkt.pos.version = 1;
+        pkt.pos.object_id = this->id_value;
+        pkt.pos.x_pos = (uint64_t)pos.x;
+        pkt.pos.y_pos = (uint64_t)pos.y;
+        pkt.pos.z_pos = (uint64_t)pos.z;
+        pkt.pos.w_orient = (uint32_t)orient.w;
+        pkt.pos.x_orient = (uint32_t)orient.x;
+        pkt.pos.y_orient = (uint32_t)orient.y;
+        pkt.pos.z_orient = (uint32_t)orient.z;
+        pkt.pos.x_look = (uint32_t)look.x;
+        pkt.pos.y_look = (uint32_t)look.y;
+        pkt.pos.z_look = (uint32_t)look.z;
+    }
+    this->leave();
 }

--- a/server/classes/game_obj.cc
+++ b/server/classes/game_obj.cc
@@ -1,6 +1,6 @@
 /* game_obj.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 13 Mar 2021, 09:25:19 tquirk
+ *   last updated 14 Mar 2021, 23:22:51 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2021  Trinity Annabelle Quirk
@@ -309,7 +309,7 @@ void GameObject::generate_update_packet(packet& pkt)
     if (this->active == false)
     {
         pkt.del.type = TYPE_OBJDEL;
-        pkt.del.version = 1;
+        pkt.del.version = R9_PROTO_VER;
         pkt.del.object_id = this->id_value;
     }
     else
@@ -319,7 +319,7 @@ void GameObject::generate_update_packet(packet& pkt)
         glm::dvec3 look = this->look * POSUPD_LOOK_SCALE;
 
         pkt.pos.type = TYPE_POSUPD;
-        pkt.pos.version = 1;
+        pkt.pos.version = R9_PROTO_VER;
         pkt.pos.object_id = this->id_value;
         pkt.pos.x_pos = (uint64_t)pos.x;
         pkt.pos.y_pos = (uint64_t)pos.y;

--- a/server/classes/game_obj.h
+++ b/server/classes/game_obj.h
@@ -1,6 +1,6 @@
 /* game_obj.h                                              -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 02 Mar 2021, 09:04:26 tquirk
+ *   last updated 13 Mar 2021, 09:24:35 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2021  Trinity Annabelle Quirk
@@ -45,6 +45,8 @@
 #include <glm/vec3.hpp>
 #include <glm/geometric.hpp>
 #include <glm/gtc/quaternion.hpp>
+
+#include "../../proto/proto.h"
 
 class GameObject;
 
@@ -130,6 +132,8 @@ class GameObject
 
     void move_and_rotate(void);
     bool still_moving(void);
+
+    void generate_update_packet(packet& pkt);
 };
 
 #endif /* __INC_GAME_OBJ_H__ */

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -1,6 +1,6 @@
 /* listensock.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 03 Mar 2021, 08:59:25 tquirk
+ *   last updated 14 Mar 2021, 23:23:08 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2021  Trinity Annabelle Quirk
@@ -189,7 +189,7 @@ void base_user::send_server_key(uint8_t *pubkey, size_t key_sz)
     packet_list pkt;
 
     pkt.buf.key.type = TYPE_SRVKEY;
-    pkt.buf.key.version = 1;
+    pkt.buf.key.version = R9_PROTO_VER;
     pkt.buf.key.sequence = this->sequence++;
     memset(pkt.buf.key.pubkey, 0, sizeof(pkt.buf.key.pubkey));
     memcpy(pkt.buf.key.pubkey, pubkey, std::min(key_sz,
@@ -204,7 +204,7 @@ void base_user::send_ping(void)
     packet_list pkt;
 
     pkt.buf.basic.type = TYPE_PNGPKT;
-    pkt.buf.basic.version = 1;
+    pkt.buf.basic.version = R9_PROTO_VER;
     pkt.buf.basic.sequence = this->sequence++;
     pkt.who = this;
     this->parent->send_pool->push(pkt);
@@ -217,7 +217,7 @@ void base_user::send_ack(uint8_t req,
     packet_list pkt;
 
     pkt.buf.ack.type = TYPE_ACKPKT;
-    pkt.buf.ack.version = 1;
+    pkt.buf.ack.version = R9_PROTO_VER;
     pkt.buf.ack.sequence = this->sequence++;
     pkt.buf.ack.request = req;
     pkt.buf.ack.misc[0] = misc0;

--- a/server/classes/update_pool.cc
+++ b/server/classes/update_pool.cc
@@ -1,9 +1,9 @@
 /* update_pool.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 28 Sep 2020, 22:24:31 tquirk
+ *   last updated 13 Mar 2021, 09:23:42 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -22,8 +22,6 @@
  *
  * The minimal implementation of the Update pool.
  */
-
-#include "../../proto/proto.h"
 
 #include "update_pool.h"
 #include "listensock.h"
@@ -62,23 +60,7 @@ void *UpdatePool::update_pool_worker(void *arg)
     {
         pool->pop(&req);
 
-        glm::dvec3 pos = req->get_position() * POSUPD_POS_SCALE;
-        glm::dquat orient = req->get_orientation() * POSUPD_ORIENT_SCALE;
-        glm::dvec3 look = req->get_look() * POSUPD_LOOK_SCALE;
-
-        pkt.buf.pos.type = TYPE_POSUPD;
-        pkt.buf.pos.version = 1;
-        pkt.buf.pos.object_id = req->get_object_id();
-        pkt.buf.pos.x_pos = (uint64_t)pos.x;
-        pkt.buf.pos.y_pos = (uint64_t)pos.y;
-        pkt.buf.pos.z_pos = (uint64_t)pos.z;
-        pkt.buf.pos.w_orient = (uint32_t)orient.w;
-        pkt.buf.pos.x_orient = (uint32_t)orient.x;
-        pkt.buf.pos.y_orient = (uint32_t)orient.y;
-        pkt.buf.pos.z_orient = (uint32_t)orient.z;
-        pkt.buf.pos.x_look = (uint32_t)look.x;
-        pkt.buf.pos.y_look = (uint32_t)look.y;
-        pkt.buf.pos.z_look = (uint32_t)look.z;
+        req->generate_update_packet(pkt.buf);
 
         /* Figure out who to send it to */
         /* Send to EVERYONE (for now) */

--- a/test/t_action_pool.cc
+++ b/test/t_action_pool.cc
@@ -142,7 +142,7 @@ void test_no_skill(void)
     action_request pkt;
     memset(&pkt, 0, sizeof(action_request));
     pkt.type = TYPE_ACTREQ;
-    pkt.version = 1;
+    pkt.version = R9_PROTO_VER;
     pkt.object_id = 9876LL;
     pkt.action_id = 12345;
     pkt.power_level = 5;
@@ -178,7 +178,7 @@ void test_invalid_skill(void)
     action_request pkt;
     memset(&pkt, 0, sizeof(action_request));
     pkt.type = TYPE_ACTREQ;
-    pkt.version = 1;
+    pkt.version = R9_PROTO_VER;
     pkt.object_id = 9876LL;
     pkt.action_id = 567;
     pkt.power_level = 5;
@@ -214,7 +214,7 @@ void test_wrong_object_id(void)
     action_request pkt;
     memset(&pkt, 0, sizeof(action_request));
     pkt.type = TYPE_ACTREQ;
-    pkt.version = 1;
+    pkt.version = R9_PROTO_VER;
     pkt.object_id = 123LL;
     pkt.action_id = 789;
     pkt.power_level = 5;
@@ -250,7 +250,7 @@ void test_good_object_id(void)
     action_request pkt;
     memset(&pkt, 0, sizeof(action_request));
     pkt.type = TYPE_ACTREQ;
-    pkt.version = 1;
+    pkt.version = R9_PROTO_VER;
     pkt.object_id = 9876LL;
     pkt.action_id = 789;
     pkt.power_level = 5;
@@ -286,7 +286,7 @@ void test_worker(void)
     packet_list pl;
     memset(&pl.buf, 0, sizeof(action_request));
     pl.buf.act.type = TYPE_ACTREQ;
-    pl.buf.act.version = 1;
+    pl.buf.act.version = R9_PROTO_VER;
     pl.buf.act.object_id = 9876LL;
     pl.buf.act.action_id = 789;
     pl.buf.act.power_level = 5;

--- a/test/t_byteswap.cc
+++ b/test/t_byteswap.cc
@@ -10,7 +10,7 @@ void test_bad_type(void)
     packet p;
 
     p.basic.type = 99;
-    p.basic.version = 1;
+    p.basic.version = R9_PROTO_VER;
     p.basic.sequence = 1234LL;
 
     is(hton_packet(&p, sizeof(basic_packet)), 0,
@@ -26,7 +26,7 @@ void test_ack_packet(void)
     packet p;
 
     p.ack.type = TYPE_ACKPKT;
-    p.ack.version = 1;
+    p.ack.version = R9_PROTO_VER;
     p.ack.sequence = 1234LL;
     p.ack.request = 42;
     p.ack.misc[0] = 2345LL;
@@ -52,7 +52,7 @@ void test_login_request(void)
     packet p;
 
     p.log.type = TYPE_LOGREQ;
-    p.log.version = 1;
+    p.log.version = R9_PROTO_VER;
     p.log.sequence = 1234LL;
 
     is(is_login_request(&p), 1, test + "is a logreq");
@@ -73,7 +73,7 @@ void test_action_request(void)
     packet p;
 
     p.act.type = TYPE_ACTREQ;
-    p.act.version = 1;
+    p.act.version = R9_PROTO_VER;
     p.act.sequence = 1234LL;
     p.act.object_id = 12345LL;
     p.act.action_id = 123;
@@ -103,7 +103,7 @@ void test_position_update(void)
     packet p;
 
     p.pos.type = TYPE_POSUPD;
-    p.pos.version = 1;
+    p.pos.version = R9_PROTO_VER;
     p.pos.sequence = 1234LL;
     p.pos.object_id = 2345LL;
     p.pos.frame_number = 123;
@@ -136,7 +136,7 @@ void test_server_notice(void)
     packet p;
 
     p.srv.type = TYPE_SRVNOT;
-    p.srv.version = 1;
+    p.srv.version = R9_PROTO_VER;
     p.srv.sequence = 1234LL;
     p.srv.ipproto = 6;
     p.srv.port = 123;
@@ -160,7 +160,7 @@ void test_ping_packet(void)
     packet p;
 
     p.basic.type = TYPE_PNGPKT;
-    p.basic.version = 1;
+    p.basic.version = R9_PROTO_VER;
     p.basic.sequence = 1234LL;
 
     is(is_ping_packet(&p), 1, test + "is a pngpkt");
@@ -181,7 +181,7 @@ void test_server_key(void)
     packet p;
 
     p.key.type = TYPE_SRVKEY;
-    p.key.version = 1;
+    p.key.version = R9_PROTO_VER;
     p.key.sequence = 1234LL;
 
     is(is_server_key(&p), 1, test + "is a srvkey");
@@ -202,7 +202,7 @@ void test_object_delete(void)
     packet p;
 
     p.del.type = TYPE_OBJDEL;
-    p.del.version = 1;
+    p.del.version = R9_PROTO_VER;
     p.del.sequence = 1234LL;
     p.del.object_id = 2345LL;
 

--- a/test/t_byteswap.cc
+++ b/test/t_byteswap.cc
@@ -105,6 +105,7 @@ void test_position_update(void)
     p.pos.type = TYPE_POSUPD;
     p.pos.version = 1;
     p.pos.sequence = 1234LL;
+    p.pos.object_id = 2345LL;
     p.pos.frame_number = 123;
     p.pos.x_pos = 1LL;
     p.pos.y_pos = 2LL;
@@ -195,9 +196,31 @@ void test_server_key(void)
        test + "good size succeeds hton");
 }
 
+void test_object_delete(void)
+{
+    std::string test = "object delete: ";
+    packet p;
+
+    p.del.type = TYPE_OBJDEL;
+    p.del.version = 1;
+    p.del.sequence = 1234LL;
+    p.del.object_id = 2345LL;
+
+    is(is_object_delete(&p), 1, test + "is an objdel");
+
+    is(ntoh_packet(&p, sizeof(object_delete) - 1), 0,
+       test + "bad size fails ntoh");
+    is(ntoh_packet(&p, sizeof(object_delete)), 1,
+       test + "good size succeeds ntoh");
+    is(hton_packet(&p, sizeof(object_delete) - 1), 0,
+       test + "bad size fails hton");
+    is(hton_packet(&p, sizeof(object_delete)), 1,
+       test + "good size succeeds hton");
+}
+
 int main(int argc, char **argv)
 {
-    plan(38);
+    plan(43);
 
     test_bad_type();
     test_ack_packet();
@@ -207,5 +230,6 @@ int main(int argc, char **argv)
     test_server_notice();
     test_ping_packet();
     test_server_key();
+    test_object_delete();
     return exit_status();
 }

--- a/test/t_comm.cc
+++ b/test/t_comm.cc
@@ -182,7 +182,7 @@ void test_send_bad_hton(void)
 
     memset((void *)pkt, 0, sizeof(packet));
     pkt->basic.type = TYPE_PNGPKT;
-    pkt->basic.version = 1;
+    pkt->basic.version = R9_PROTO_VER;
 
     bad_hton = true;
     bad_encrypt = false;
@@ -219,7 +219,7 @@ void test_send_bad_encrypt(void)
 
     memset((void *)pkt, 0, sizeof(packet));
     pkt->basic.type = TYPE_ACTREQ;
-    pkt->basic.version = 1;
+    pkt->basic.version = R9_PROTO_VER;
 
     bad_hton = false;
     bad_encrypt = true;
@@ -256,7 +256,7 @@ void test_send_bad_send(void)
 
     memset((void *)pkt, 0, sizeof(packet));
     pkt->basic.type = TYPE_PNGPKT;
-    pkt->basic.version = 1;
+    pkt->basic.version = R9_PROTO_VER;
 
     bad_hton = false;
     bad_encrypt = false;
@@ -293,7 +293,7 @@ void test_send_packet(void)
 
     memset((void *)pkt, 0, sizeof(packet));
     pkt->basic.type = TYPE_PNGPKT;
-    pkt->basic.version = 1;
+    pkt->basic.version = R9_PROTO_VER;
 
     try
     {
@@ -428,7 +428,7 @@ void test_recv_bad_result(void)
 
     memset((void *)&expected_packet, 0, sizeof(packet));
     expected_packet.basic.type = TYPE_PNGPKT;
-    expected_packet.basic.version = 1;
+    expected_packet.basic.version = R9_PROTO_VER;
 
     recvfrom_error = true;
     bad_sender = false;
@@ -462,7 +462,7 @@ void test_recv_bad_sender(void)
 
     memset((void *)&expected_packet, 0, sizeof(packet));
     expected_packet.basic.type = TYPE_PNGPKT;
-    expected_packet.basic.version = 1;
+    expected_packet.basic.version = R9_PROTO_VER;
 
     recvfrom_error = false;
     bad_sender = true;
@@ -506,7 +506,7 @@ void test_recv_bad_packet(void)
 
     memset((void *)&expected_packet, 0, sizeof(packet));
     expected_packet.basic.type = TYPE_PNGPKT;
-    expected_packet.basic.version = 1;
+    expected_packet.basic.version = R9_PROTO_VER;
 
     recvfrom_error = false;
     bad_sender = false;
@@ -549,7 +549,7 @@ void test_recv_no_decrypt(void)
 
     memset((void *)&expected_packet, 0, sizeof(packet));
     expected_packet.basic.type = TYPE_ACKPKT;
-    expected_packet.basic.version = 1;
+    expected_packet.basic.version = R9_PROTO_VER;
 
     recvfrom_error = false;
     bad_sender = false;
@@ -593,7 +593,7 @@ void test_recv_no_ntoh(void)
 
     memset((void *)&expected_packet, 0, sizeof(packet));
     expected_packet.basic.type = TYPE_ACKPKT;
-    expected_packet.basic.version = 1;
+    expected_packet.basic.version = R9_PROTO_VER;
 
     recvfrom_error = false;
     bad_sender = false;
@@ -637,7 +637,7 @@ void test_recv_packet(void)
 
     memset((void *)&expected_packet, 0, sizeof(packet));
     expected_packet.basic.type = TYPE_SRVNOT;
-    expected_packet.basic.version = 1;
+    expected_packet.basic.version = R9_PROTO_VER;
 
     recvfrom_error = false;
     bad_sender = false;
@@ -672,7 +672,7 @@ void test_recv_ping(void)
 
     memset((void *)&expected_packet, 0, sizeof(packet));
     expected_packet.basic.type = TYPE_PNGPKT;
-    expected_packet.basic.version = 1;
+    expected_packet.basic.version = R9_PROTO_VER;
 
     try
     {
@@ -696,7 +696,7 @@ void test_recv_ack(void)
 
     memset((void *)&expected_packet, 0, sizeof(packet));
     expected_packet.basic.type = TYPE_ACKPKT;
-    expected_packet.basic.version = 1;
+    expected_packet.basic.version = R9_PROTO_VER;
 
     try
     {
@@ -771,7 +771,7 @@ void test_recv_pos_update(void)
 
     memset((void *)&expected_packet, 0, sizeof(packet));
     expected_packet.basic.type = TYPE_POSUPD;
-    expected_packet.basic.version = 1;
+    expected_packet.basic.version = R9_PROTO_VER;
     expected_packet.pos.x_pos = 12;
     expected_packet.pos.y_pos = 34;
     expected_packet.pos.z_pos = 56;
@@ -804,7 +804,7 @@ void test_recv_server_notice(void)
 
     memset((void *)&expected_packet, 0, sizeof(packet));
     expected_packet.basic.type = TYPE_SRVNOT;
-    expected_packet.basic.version = 1;
+    expected_packet.basic.version = R9_PROTO_VER;
 
     try
     {
@@ -830,7 +830,7 @@ void test_recv_server_key(void)
 
     memset((void *)&expected_packet, 0, sizeof(packet));
     expected_packet.basic.type = TYPE_SRVKEY;
-    expected_packet.basic.version = 1;
+    expected_packet.basic.version = R9_PROTO_VER;
 
     try
     {
@@ -881,7 +881,7 @@ void test_recv_unsupported(void)
 
     memset((void *)&expected_packet, 0, sizeof(packet));
     expected_packet.basic.type = 123;
-    expected_packet.basic.version = 1;
+    expected_packet.basic.version = R9_PROTO_VER;
 
     try
     {


### PR DESCRIPTION
First shot at removing objects from clients.  This is only for characters which logout.  Objects that go away completely are not yet handled.