### PR TITLE
Make comment blocks consistent

### DIFF
--- a/server/classes/actions/register.h
+++ b/server/classes/actions/register.h
@@ -1,9 +1,9 @@
-/* register.h
+/* register.h                                              -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 31 Aug 2017, 14:52:15 tquirk
+ *   last updated 07 Aug 2024, 09:15:49 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2017  Trinity Annabelle Quirk
+ * Copyright (C) 2024  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/socket.cc
+++ b/server/classes/socket.cc
@@ -1,3 +1,31 @@
+/* socket.cc
+ *   by Trinity Quirk <tquirk@ymb.net>
+ *   last updated 07 Aug 2024, 09:14:44 tquirk
+ *
+ * Revision IX game server
+ * Copyright (C) 2024  Trinity Annabelle Quirk
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ *
+ * This file contains a socket creation factory.
+ *
+ * Things to do
+ *
+ */
+
 #include <string>
 #include <stdexcept>
 

--- a/server/classes/socket.h
+++ b/server/classes/socket.h
@@ -1,3 +1,31 @@
+/* socket.h                                                -*- C++ -*-
+ *   by Trinity Quirk <tquirk@ymb.net>
+ *   last updated 07 Aug 2024, 09:14:18 tquirk
+ *
+ * Revision IX game server
+ * Copyright (C) 2024  Trinity Annabelle Quirk
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ *
+ * This file contains socket creation factory prototypes.
+ *
+ * Things to do
+ *
+ */
+
 #ifndef __INC_R9_SOCKET_H__
 #define __INC_R9_SOCKET_H__
 

--- a/server/server.h
+++ b/server/server.h
@@ -1,9 +1,9 @@
-/* server.h
+/* server.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 19 Apr 2018, 07:33:27 tquirk
+ *   last updated 07 Aug 2024, 09:16:10 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2018  Trinity Annabelle Quirk
+ * Copyright (C) 2024  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/signals.h
+++ b/server/signals.h
@@ -1,9 +1,9 @@
-/* signals.h
+/* signals.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 24 Jul 2015, 13:21:20 tquirk
+ *   last updated 07 Aug 2024, 09:16:31 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2015  Trinity Annabelle Quirk
+ * Copyright (C) 2024  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License


### PR DESCRIPTION
All files should have the standard comment block.  C++ headers should have the `-*- C++ -*-` signifier at the top so they get handled properly by editors and Github language sensing.