### PR TITLE
Improve client i18n strings

### DIFF
--- a/client/comm_dialog.cc
+++ b/client/comm_dialog.cc
@@ -1,9 +1,9 @@
 /* comm_dialog.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 13 Apr 2021, 08:08:49 tquirk
+ *   last updated 15 Apr 2025, 08:07:47 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2025  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -150,9 +150,9 @@ void setup_comm_callback(ui::active *t, void *call, void *client)
     snprintf(portstr, sizeof(portstr), "%d", config.server_port);
     if ((ret = getaddrinfo(host_str.c_str(), portstr, &hints, &ai)) != 0)
     {
-        std::cout << format(translate("Couldn't find host {1}: {2} ({3})"))
-            % host_str % gai_strerror(ret) % ret
-                  << std::endl;
+        std::cout << format(
+            translate("Error finding host {1,name}: {2,errmsg} ({3,errno})")
+        ) % host_str % gai_strerror(ret) % ret << std::endl;
         return;
     }
     config.read_crypto_key(pass_str);

--- a/client/configdata.cc
+++ b/client/configdata.cc
@@ -1,9 +1,9 @@
 /* configdata.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 17 Apr 2021, 08:11:19 tquirk
+ *   last updated 15 Apr 2025, 08:13:16 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2025  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -179,7 +179,7 @@ void ConfigData::parse_command_line(int count, const char **args)
             else if ((*j) == "-f")
                 this->config_fname = *(++j);
             else
-                std::clog << format(translate("Unknown option {1}")) % *j
+                std::clog << format(translate("Unknown option {1,name}")) % *j
                           << std::endl;
         }
     }
@@ -208,9 +208,9 @@ void ConfigData::read_config_file(void)
         try { this->parse_config_line(str); }
         catch (std::out_of_range& e)
         {
-            std::clog << format(translate("Skipping bad config line \"{1}\""))
-                % pristine_str
-                      << std::endl;
+            std::clog << format(
+                translate("Skipping bad config line \"{1,content}\"")
+            ) % pristine_str << std::endl;
         }
     }
 }
@@ -264,9 +264,12 @@ void ConfigData::make_config_dirs(void)
         std::ostringstream s;
         char err[128];
 
-        strerror_r(errno, err, sizeof(err));
-        s << format(translate("Error creating config directory {1}: {2} ({3})"))
-          % dirname % err % errno;
+        s << format(
+            translate(
+                "Error creating config directory {1,name}: "
+                "{2,errmsg} ({3,errno})"
+            )
+        ) % dirname % strerror_r(errno, err, sizeof(err)) % errno;
         throw std::runtime_error(s.str());
     }
 
@@ -277,9 +280,12 @@ void ConfigData::make_config_dirs(void)
         std::ostringstream s;
         char err[128];
 
-        strerror_r(errno, err, sizeof(err));
-        s << format(translate("Error creating config directory {1}: {2} ({3})"))
-            % subdirname % err % errno;
+        s << format(
+            translate(
+                "Error creating config directory {1,name}: "
+                "{2,errmsg} ({3,errno})"
+            )
+        ) % subdirname % strerror_r(errno, err, sizeof(err)) % errno;
         throw std::runtime_error(s.str());
     }
 
@@ -289,9 +295,12 @@ void ConfigData::make_config_dirs(void)
         std::ostringstream s;
         char err[128];
 
-        strerror_r(errno, err, sizeof(err));
-        s << format(translate("Error creating config directory {1}: {2} ({3})"))
-            % subdirname % err % errno;
+        s << format(
+            translate(
+                "Error creating config directory {1,name}: "
+                "{2,errmsg} ({3,errno})"
+            )
+        ) % subdirname % strerror_r(errno, err, sizeof(err)) % errno;
         throw std::runtime_error(s.str());
     }
 
@@ -301,9 +310,12 @@ void ConfigData::make_config_dirs(void)
         std::ostringstream s;
         char err[128];
 
-        strerror_r(errno, err, sizeof(err));
-        s << format(translate("Error creating config directory {1}: {2} ({3})"))
-            % subdirname % err % errno;
+        s << format(
+            translate(
+                "Error creating config directory {1,name}: "
+                "{2,errmsg} ({3,errno})"
+            )
+        ) % subdirname % strerror_r(errno, err, sizeof(err)) % errno;
         throw std::runtime_error(s.str());
     }
 }
@@ -378,8 +390,9 @@ static void read_paths(const std::string& key,
             char *home;
 
             if ((home = getenv("HOME")) == NULL)
-                throw std::runtime_error(translate("Could not find "
-                                                   "home directory"));
+                throw std::runtime_error(
+                    translate("Could not find home directory")
+                );
             path.replace(pos, 1, home);
         }
         if (stat(path.c_str(), &state) != -1)

--- a/client/control/control.cc
+++ b/client/control/control.cc
@@ -1,9 +1,9 @@
 /* control.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 13 Apr 2021, 08:21:34 tquirk
+ *   last updated 15 Apr 2025, 09:03:01 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2025  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -44,12 +44,12 @@ static std::string glob_error_to_string(int err)
 {
     switch (err)
     {
-      case 1:   return translate("Out of memory");
-      case 2:   return translate("Read error");
-      case 3:   return translate("No match found");
-      case 4:   return translate("Function not implemented");
+      case 1:   return translate("Error message", "Out of memory");
+      case 2:   return translate("Error message", "Read error");
+      case 3:   return translate("Error message", "No match found");
+      case 4:   return translate("Error message", "Function not implemented");
     }
-    return translate("Unknown error");
+    return translate("Error message", "Unknown error");
 }
 
 std::vector<std::string> control_factory::types(void)
@@ -62,8 +62,9 @@ std::vector<std::string> control_factory::types(void)
     {
         std::ostringstream s;
 
-        s << format(translate("Could not find control modules: {1} ({2})"))
-            % glob_error_to_string(errno) % errno;
+        s << format(
+            translate("Could not find control modules: {1,errmsg} ({2,errno})")
+        ) % glob_error_to_string(errno) % errno;
         throw std::runtime_error(s.str());
     }
     for (int i = 0; i < mods.gl_pathc; ++i)
@@ -92,7 +93,9 @@ control *control_factory::create(const std::string& control_type)
         if ((err = dlerror()) != NULL)
         {
             std::ostringstream s;
-            s << "Could not close library " << fname << ": " << err;
+            s << format(
+                translate("Could not close library {1,name}: {2,errmsg}")
+            ) % fname % err;
             throw std::runtime_error(s.str());
         }
     }
@@ -101,7 +104,9 @@ control *control_factory::create(const std::string& control_type)
     if ((err = dlerror()) != NULL)
     {
         std::ostringstream s;
-        s << "Could not open library " << fname << ": " << err;
+        s << format(
+            translate("Could not open library {1,name}: {2,errmsg}")
+        ) % fname % err;
         throw std::runtime_error(s.str());
     }
     dlerror();
@@ -109,7 +114,9 @@ control *control_factory::create(const std::string& control_type)
     if ((err = dlerror()) != NULL)
     {
         std::ostringstream s;
-        s << "Could not find create symbol: " << err;
+        s << format(
+            translate("Could not find create symbol: {1,errmsg}")
+        ) % err;
         throw std::runtime_error(s.str());
     }
     dlerror();

--- a/client/log_display.cc
+++ b/client/log_display.cc
@@ -1,9 +1,9 @@
 /* log_display.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 01 Nov 2020, 09:16:32 tquirk
+ *   last updated 15 Apr 2025, 08:01:15 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2025  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -46,6 +46,8 @@
 #include <cuddly-gl/ui_defs.h>
 #include "log_display.h"
 #include <cuddly-gl/label.h>
+
+#include "l10n.h"
 
 const int log_display::ENTRY_LIFETIME = 10;
 
@@ -181,9 +183,12 @@ void log_display::init(void)
         std::ostringstream s;
         char err[128];
 
-        strerror_r(ret, err, sizeof(err));
-        s << "Couldn't start log display cleanup thread: "
-          << err << " (" << ret << ")";
+        s << format(
+            translate(
+                "Error starting log display cleanup thread: "
+                "{1,errmsg} ({2,errno})"
+            )
+        ) % strerror_r(ret, err, sizeof(err)) % ret;
         throw std::runtime_error(s.str());
     }
 
@@ -210,26 +215,34 @@ log_display::~log_display()
     {
         char err[128];
 
-        strerror_r(ret, err, sizeof(err));
-        std::clog << "Couldn't cancel log display cleanup thread: "
-                  << err << " (" << ret << ")" << std::endl;
+        std::clog << format(
+            translate(
+                "Error cancelling log display cleanup thread: "
+                "{1,errmsg} ({2,errno})"
+            )
+        ) % strerror_r(ret, err, sizeof(err)) % ret << std::endl;
     }
     sleep(0);
     if ((ret = pthread_join(this->cleanup_thread, NULL)) != 0)
     {
         char err[128];
 
-        strerror_r(ret, err, sizeof(err));
-        std::clog << "Couldn't reap log display cleanup thread: "
-                  << err << " (" << ret << ")" << std::endl;
+        std::clog << format(
+            translate(
+                "Error joining log display cleanup thread: "
+                "{1,errmsg} ({2,errno})"
+            )
+        ) % strerror_r(ret, err, sizeof(err)) % ret << std::endl;
     }
     if ((ret = pthread_mutex_destroy(&this->queue_mutex)) != 0)
     {
         char err[128];
 
-        strerror_r(ret, err, sizeof(err));
-        std::clog << "Couldn't destroy log display mutex: "
-                  << err << " (" << ret << ")" << std::endl;
+        std::clog << format(
+            translate(
+                "Error destroying log display mutex: {1,errmsg} ({2,errno})"
+            )
+        ) % strerror_r(ret, err, sizeof(err)) % ret << std::endl;
     }
 
     this->sync_to_file();

--- a/client/shader.cc
+++ b/client/shader.cc
@@ -1,9 +1,9 @@
 /* shader.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 13 Apr 2021, 08:05:36 tquirk
+ *   last updated 15 Apr 2025, 07:33:47 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2025  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -51,7 +51,7 @@ GLuint load_shader(GLenum type, const std::string& file)
     {
         std::ostringstream s;
 
-        s << format(translate("could not open file {1}")) % file;
+        s << format(translate("Error opening file {1,name}")) % file;
         throw std::runtime_error(s.str());
     }
     infile.seekg(0, std::ios::end);
@@ -74,8 +74,9 @@ GLuint create_shader(GLenum type, const std::string& src)
 
     if (shader == 0)
     {
-        s << format(translate("Could not create shader: {1}"))
-            % GLenum_to_string(glGetError());
+        s << format(
+            translate("Error creating shader {1,name}: {2,errmsg}")
+        ) % GLenum_to_string(type) % GLenum_to_string(glGetError());
         throw std::runtime_error(s.str());
     }
 
@@ -118,7 +119,7 @@ GLuint create_program(GLuint vert, GLuint geom, GLuint frag, const char *out)
 
     if (pgm == 0)
     {
-        s << format(translate("Could not create GL program: {1}"))
+        s << format(translate("Error creating GL program: {1,errmsg}"))
             % GLenum_to_string(glGetError());
         throw std::runtime_error(s.str());
     }
@@ -132,7 +133,7 @@ GLuint create_program(GLuint vert, GLuint geom, GLuint frag, const char *out)
         glAttachShader(pgm, frag);
     if ((err = glGetError()) != GL_NO_ERROR)
     {
-        s << format(translate("Could not attach shaders to program: {1}"))
+        s << format(translate("Error attaching shaders to program: {1,errmsg}"))
             % GLenum_to_string(err);
         glDeleteProgram(pgm);
         throw std::runtime_error(s.str());
@@ -177,6 +178,7 @@ std::string GLenum_to_string(GLenum e)
       case GL_STACK_UNDERFLOW:   s = "GL_STACK_UNDERFLOW"; break;
       case GL_OUT_OF_MEMORY:     s = "GL_OUT_OF_MEMORY"; break;
       case GL_TABLE_TOO_LARGE:   s = "GL_TABLE_TOO_LARGE"; break;
+
       case GL_VERTEX_SHADER:     s = "GL_VERTEX_SHADER"; break;
       case GL_GEOMETRY_SHADER:   s = "GL_GEOMETRY_SHADER"; break;
       case GL_FRAGMENT_SHADER:   s = "GL_FRAGMENT_SHADER"; break;

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,12 +1,10 @@
 # List of source files which contain translatable strings.
 client/client.cc
-client/client.h
 client/client_core.cc
-client/client_core.h
 client/comm.cc
-client/comm.h
 client/comm_dialog.cc
 client/configdata.cc
-client/configdata.h
-client/object.h
+client/control/control.cc
+client/log_display.cc
+client/shader.cc
 util/r9_keygen.cc

--- a/po/r9.pot
+++ b/po/r9.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: r9 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/adminspotter/r9/issues\n"
-"POT-Creation-Date: 2021-04-17 08:12-0700\n"
+"POT-Creation-Date: 2025-04-15 09:03-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -47,86 +47,82 @@ msgid "modify"
 msgstr ""
 
 #: client/comm.cc:112
-msgid "Error opening socket: {1} ({2})"
+msgid "Error opening socket: {1,errstr} ({2,errno})"
 msgstr ""
 
-#: client/comm.cc:204
-msgid "Error sending packet: {1} ({2})"
+#: client/comm.cc:205
+msgid "Error sending packet: {1,errstr} ({2,errno})"
 msgstr ""
 
 #: client/comm.cc:237
-msgid "Error receiving packet: {1} ({2})"
+msgid "Error receiving packet: {1,errstr} ({2,errno})"
 msgstr ""
 
-#: client/comm.cc:245
+#: client/comm.cc:244
 msgid "Packet from unknown sender"
 msgstr ""
 
-#: client/comm.cc:252 client/comm.cc:358
-msgid "Unknown packet type {1}"
+#: client/comm.cc:251 client/comm.cc:357
+msgid "Unknown packet type {1,type}"
 msgstr ""
 
-#: client/comm.cc:259
+#: client/comm.cc:258
 msgid "Error decrypting packet"
 msgstr ""
 
-#: client/comm.cc:266
-msgid "Error ntoh'ing packet"
+#: client/comm.cc:265 client/comm.cc:529
+msgid "Error reordering packet"
 msgstr ""
 
 #: client/comm.cc:288
-msgid "Login response, {1} access"
+msgid "Login response, {1,Access type} access"
 msgstr ""
 
 #: client/comm.cc:297
-msgid "Logout response, {1} access"
+msgid "Logout response, {1,Access type} access"
 msgstr ""
 
-#: client/comm.cc:340
+#: client/comm.cc:339
 msgid "Bad public key from server"
 msgstr ""
 
-#: client/comm.cc:346
+#: client/comm.cc:345
 msgid "Could not derive shared secret with server"
 msgstr ""
 
-#: client/comm.cc:380
-msgid "Error initializing queue mutex: {1} ({2})"
+#: client/comm.cc:379
+msgid "Error initializing queue mutex: {1,errmsg} ({2,errno})"
 msgstr ""
 
 #: client/comm.cc:390
-msgid "Error initializing queue-not-empty cond: {1} ({2})"
+msgid "Error initializing queue-not-empty cond: {1,errmsg} ({2,errno})"
 msgstr ""
 
-#: client/comm.cc:436
-msgid "Error starting send thread: {1} ({2})"
+#: client/comm.cc:437
+msgid "Error starting send thread: {1,errmsg} ({2,errno})"
 msgstr ""
 
-#: client/comm.cc:451
-msgid "Error starting receive thread: {1} ({2})"
+#: client/comm.cc:452
+msgid "Error starting receive thread: {1,errmsg} ({2,errno})"
 msgstr ""
 
-#: client/comm.cc:479
-msgid "Error waking send thread: {1} ({2})"
+#: client/comm.cc:480
+msgid "Error waking send thread: {1,errmsg} ({2,errno})"
 msgstr ""
 
-#: client/comm.cc:490
-msgid "Error joining send thread: {1} ({2})"
+#: client/comm.cc:491
+msgid "Error joining send thread: {1,errmsg} ({2,errno})"
 msgstr ""
 
-#: client/comm.cc:500
-msgid "Error cancelling receive thread: {1} ({2})"
+#: client/comm.cc:502
+msgid "Error cancelling receive thread: {1,errmsg} ({2,errno})"
 msgstr ""
 
-#: client/comm.cc:511
-msgid "Error joining receive thread: {1} ({2})"
+#: client/comm.cc:515
+msgid "Error joining receive thread: {1,errmsg} ({2,errno})"
 msgstr ""
 
-#: client/comm.cc:524
-msgid "Error hton'ing packet"
-msgstr ""
-
-#: client/comm.cc:529
+#: client/comm.cc:534
 msgid "Error encrypting packet"
 msgstr ""
 
@@ -150,51 +146,124 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: client/comm_dialog.cc:153
-msgid "Couldn't find host {1}: {2} ({3})"
+#: client/comm_dialog.cc:154
+msgid "Error finding host {1,name}: {2,errmsg} ({3,errno})"
 msgstr ""
 
-#: client/configdata.cc:182 util/r9_keygen.cc:115
-msgid "Unknown option {1}"
+#: client/configdata.cc:182 util/r9_keygen.cc:116
+msgid "Unknown option {1,name}"
 msgstr ""
 
-#: client/configdata.cc:211
-msgid "Skipping bad config line \"{1}\""
+#: client/configdata.cc:212
+msgid "Skipping bad config line \"{1,content}\""
 msgstr ""
 
-#: client/configdata.cc:268 client/configdata.cc:281 client/configdata.cc:293
-#: client/configdata.cc:305
-msgid "Error creating config directory {1}: {2} ({3})"
+#: client/configdata.cc:269 client/configdata.cc:285 client/configdata.cc:300
+#: client/configdata.cc:315
+msgid "Error creating config directory {1,name}: {2,errmsg} ({3,errno})"
 msgstr ""
 
-#: client/configdata.cc:381
+#: client/configdata.cc:394
 msgid "Could not find home directory"
+msgstr ""
+
+#: client/control/control.cc:47
+msgctxt "Error message"
+msgid "Out of memory"
+msgstr ""
+
+#: client/control/control.cc:48
+msgctxt "Error message"
+msgid "Read error"
+msgstr ""
+
+#: client/control/control.cc:49
+msgctxt "Error message"
+msgid "No match found"
+msgstr ""
+
+#: client/control/control.cc:50
+msgctxt "Error message"
+msgid "Function not implemented"
+msgstr ""
+
+#: client/control/control.cc:52
+msgctxt "Error message"
+msgid "Unknown error"
+msgstr ""
+
+#: client/control/control.cc:66
+msgid "Could not find control modules: {1,errmsg} ({2,errno})"
+msgstr ""
+
+#: client/control/control.cc:97
+msgid "Could not close library {1,name}: {2,errmsg}"
+msgstr ""
+
+#: client/control/control.cc:108
+msgid "Could not open library {1,name}: {2,errmsg}"
+msgstr ""
+
+#: client/control/control.cc:118
+msgid "Could not find create symbol: {1,errmsg}"
+msgstr ""
+
+#: client/log_display.cc:188
+msgid "Error starting log display cleanup thread: {1,errmsg} ({2,errno})"
+msgstr ""
+
+#: client/log_display.cc:220
+msgid "Error cancelling log display cleanup thread: {1,errmsg} ({2,errno})"
+msgstr ""
+
+#: client/log_display.cc:232
+msgid "Error joining log display cleanup thread: {1,errmsg} ({2,errno})"
+msgstr ""
+
+#: client/log_display.cc:243
+msgid "Error destroying log display mutex: {1,errmsg} ({2,errno})"
+msgstr ""
+
+#: client/shader.cc:54
+msgid "Error opening file {1,name}"
+msgstr ""
+
+#: client/shader.cc:78
+msgid "Error creating shader {1,name}: {2,errmsg}"
+msgstr ""
+
+#: client/shader.cc:122
+msgid "Error creating GL program: {1,errmsg}"
+msgstr ""
+
+#: client/shader.cc:136
+msgid "Error attaching shaders to program: {1,errmsg}"
 msgstr ""
 
 #: util/r9_keygen.cc:95 util/r9_keygen.cc:105
 msgid "Can't do both server and client keys"
 msgstr ""
 
-#: util/r9_keygen.cc:120
+#: util/r9_keygen.cc:121
 msgid "Error in argument parsing"
 msgstr ""
 
-#: util/r9_keygen.cc:140
-msgid "Writing to {1}"
+#: util/r9_keygen.cc:142
+msgid "Writing to {1,name}"
 msgstr ""
 
-#: util/r9_keygen.cc:152
+#: util/r9_keygen.cc:155
 msgid "Passphrases do not match!"
 msgstr ""
 
-#: util/r9_keygen.cc:153
+#: util/r9_keygen.cc:156
 msgid "Enter passphrase: "
 msgstr ""
 
-#: util/r9_keygen.cc:160
+#: util/r9_keygen.cc:163
 msgid "Repeat passphrase: "
 msgstr ""
 
-#: util/r9_keygen.cc:186
-msgid "Error writing private key file: {1} ({2})"
+#: util/r9_keygen.cc:190
+msgid "Error writing private key file: {1,errmsg} ({2,errno})"
 msgstr ""

--- a/util/r9_keygen.cc
+++ b/util/r9_keygen.cc
@@ -1,9 +1,9 @@
 /* r9_keygen.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 17 Apr 2021, 08:11:56 tquirk
+ *   last updated 15 Apr 2025, 08:47:26 tquirk
  *
  * Revision IX game utility
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2025  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -112,8 +112,9 @@ void process_command_line(int argc, char **argv)
             break;
           case '?':
 #if !HAVE_GETOPT_LONG
-            std::cerr << format(translate("Unknown option {1}")) % (char)opt
-                      << std::endl;
+            std::cerr << format(
+                translate("Unknown option {1,name}")
+            ) % (char)opt << std::endl;
 #endif /* !HAVE_GETOPT_LONG */
             exit(ARGPARSE_RETURN);
           default:
@@ -137,7 +138,9 @@ void generate_key_path(void)
         else
             key_path = "./key";
     }
-    std::cout << format(translate("Writing to {1}")) % key_path << std::endl;
+    std::cout << format(
+        translate("Writing to {1,name}")
+    ) % key_path << std::endl;
 }
 
 std::string ask_for_passphrase(void)
@@ -183,9 +186,9 @@ void write_key(EVP_PKEY *key, std::string& key_fname, std::string& passphrase)
 
     if (pkey_to_file(key, key_fname.c_str(), pp) == 0)
     {
-        std::cerr << format(translate("Error writing private key "
-                                      "file: {1} ({2})"))
-            % strerror(errno) % errno << std::endl;
+        std::cerr << format(
+            translate("Error writing private key file: {1,errmsg} ({2,errno})")
+        ) % strerror(errno) % errno << std::endl;
         exit(KEYGEN_RETURN);
     }
     if (do_client_key == true)


### PR DESCRIPTION
We can annotate the placeholders within strings to be translated, to help translators figure out just what will be in those inserted sections.

We had been missing a few files which had translatable strings, so those are now being included.  None of the headers which were listed in the files-to-be-translated had translatable strings, so we dropped them.