### PR TITLE
Remove last updated from comment headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ long as the commit chain makes sense, is documented well by the
 follows a good logical flow, they'll be perfectly acceptable.  Tag
 relevant commits or issues in your commit messages.  Add your name to
 the AUTHORS file and the comment block at the top of the files you
-change.  It's not amazingly important to update the 'last updated'
-lines at the tops of files, but it would be nice. :)
+change.
 
 Code is licensed GPL2.

--- a/client/client.cc
+++ b/client/client.cc
@@ -1,9 +1,8 @@
 /* client.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 16 Apr 2021, 23:27:16 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2016-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/client.h
+++ b/client/client.h
@@ -1,9 +1,8 @@
 /* client.h
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 01 Nov 2020, 09:16:13 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 1998-2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/client_core.cc
+++ b/client/client_core.cc
@@ -1,9 +1,8 @@
 /* client_core.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 01 Feb 2020, 18:07:12 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2015-2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/client_core.h
+++ b/client/client_core.h
@@ -1,9 +1,8 @@
 /* client_core.h
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 07 Dec 2019, 21:53:04 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2015-2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/comm.cc
+++ b/client/comm.cc
@@ -1,9 +1,8 @@
 /* comm.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 15 Apr 2025, 08:37:36 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2025  Trinity Annabelle Quirk
+ * Copyright (C) 1999-2025  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/comm.h
+++ b/client/comm.h
@@ -1,9 +1,8 @@
 /* comm.h                                                  -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 13 Apr 2021, 08:03:24 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2014-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/comm_dialog.cc
+++ b/client/comm_dialog.cc
@@ -1,9 +1,8 @@
 /* comm_dialog.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 15 Apr 2025, 08:07:47 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2025  Trinity Annabelle Quirk
+ * Copyright (C) 2016-2025  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/configdata.cc
+++ b/client/configdata.cc
@@ -1,9 +1,8 @@
 /* configdata.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 15 Apr 2025, 08:13:16 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2025  Trinity Annabelle Quirk
+ * Copyright (C) 2006-2025  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/configdata.h
+++ b/client/configdata.h
@@ -1,9 +1,8 @@
 /* configdata.h                                            -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 14 Dec 2020, 07:33:34 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2014-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/control/control.cc
+++ b/client/control/control.cc
@@ -1,9 +1,8 @@
 /* control.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 15 Apr 2025, 09:03:01 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2025  Trinity Annabelle Quirk
+ * Copyright (C) 2021-2025  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/control/control.h
+++ b/client/control/control.h
@@ -1,9 +1,8 @@
 /* control.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 12 Dec 2020, 23:14:58 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2019-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/control/keyboard.cc
+++ b/client/control/keyboard.cc
@@ -1,9 +1,8 @@
 /* keyboard.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 25 Feb 2021, 08:49:15 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2019-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/control/keyboard.h
+++ b/client/control/keyboard.h
@@ -1,9 +1,8 @@
 /* keyboard.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 10 Jan 2021, 12:34:57 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2019-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/l10n.h
+++ b/client/l10n.h
@@ -1,9 +1,8 @@
 /* l10n.h
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 12 Apr 2021, 22:07:13 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2015-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/log_display.cc
+++ b/client/log_display.cc
@@ -1,9 +1,8 @@
 /* log_display.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 15 Apr 2025, 08:01:15 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2025  Trinity Annabelle Quirk
+ * Copyright (C) 2016-2025  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/log_display.h
+++ b/client/log_display.h
@@ -1,9 +1,8 @@
 /* log_display.h                                           -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 01 Nov 2020, 09:16:38 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2017-2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/object.h
+++ b/client/object.h
@@ -1,9 +1,8 @@
 /* object.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 07 Dec 2019, 21:57:07 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2015-2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/shader.cc
+++ b/client/shader.cc
@@ -1,9 +1,8 @@
 /* shader.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 15 Apr 2025, 07:33:47 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2025  Trinity Annabelle Quirk
+ * Copyright (C) 2016-2025  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/client/shader.h
+++ b/client/shader.h
@@ -1,9 +1,8 @@
 /* shader.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 13 Mar 2016, 10:34:49 tquirk
  *
  * Revision IX game client
- * Copyright (C) 2016  Trinity Annabelle Quirk
+ * Copyright (C) 2017  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/proto/byteswap.c
+++ b/proto/byteswap.c
@@ -1,9 +1,8 @@
 /* byteswap.c
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 13 Mar 2021, 08:20:47 tquirk
  *
  * Revision IX game protocol
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2015-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/proto/byteswap.h
+++ b/proto/byteswap.h
@@ -1,6 +1,5 @@
 /* byteswap.h
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 11 Jun 2019, 08:31:04 tquirk
  *
  * Revision IX game protocol
  * Copyright (C) 2019  Trinity Annabelle Quirk

--- a/proto/dh.c
+++ b/proto/dh.c
@@ -1,9 +1,8 @@
 /* dh.c
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 May 2019, 12:09:35 tquirk
  *
  * Revision IX game protocol
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2018-2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/proto/dh.h
+++ b/proto/dh.h
@@ -1,9 +1,8 @@
 /* dh.h
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 18 May 2019, 11:16:49 tquirk
  *
  * Revision IX game protocol
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2018-2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/proto/ec.c
+++ b/proto/ec.c
@@ -1,9 +1,8 @@
 /* ec.c
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 02 Jun 2019, 22:25:36 tquirk
  *
  * Revision IX game protocol
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2018-2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/proto/ec.h
+++ b/proto/ec.h
@@ -1,9 +1,8 @@
 /* ec.h
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 06 Jun 2019, 08:08:19 tquirk
  *
  * Revision IX game protocol
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2018-2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/proto/encrypt.c
+++ b/proto/encrypt.c
@@ -1,6 +1,5 @@
 /* encrypt.c
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 16 Jul 2019, 21:58:24 tquirk
  *
  * Revision IX game protocol
  * Copyright (C) 2019  Trinity Annabelle Quirk

--- a/proto/encrypt.h
+++ b/proto/encrypt.h
@@ -1,6 +1,5 @@
 /* encrypt.h
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 12 Jun 2019, 06:26:32 tquirk
  *
  * Revision IX game protocol
  * Copyright (C) 2019  Trinity Annabelle Quirk

--- a/proto/key.c
+++ b/proto/key.c
@@ -1,9 +1,8 @@
 /* key.c
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 13 Apr 2019, 14:28:25 tquirk
  *
  * Revision IX game protocol
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2018-2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/proto/key.h
+++ b/proto/key.h
@@ -1,9 +1,8 @@
 /* key.h
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 13 Apr 2019, 14:32:58 tquirk
  *
  * Revision IX game protocol
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2018-2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/proto/proto.h
+++ b/proto/proto.h
@@ -1,9 +1,8 @@
 /* proto.h
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 14 Mar 2021, 23:26:22 tquirk
  *
  * Revision IX game protocol
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2000-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/action.h
+++ b/server/classes/action.h
@@ -1,6 +1,5 @@
 /* action.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 23 Dec 2019, 19:39:18 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2019  Trinity Annabelle Quirk

--- a/server/classes/action_pool.cc
+++ b/server/classes/action_pool.cc
@@ -1,9 +1,8 @@
 /* action_pool.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 02 Feb 2021, 14:11:00 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2015-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/action_pool.h
+++ b/server/classes/action_pool.h
@@ -1,9 +1,8 @@
 /* action_pool.h                                           -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 24 Dec 2020, 15:28:52 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2015-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/actions/control_object.cc
+++ b/server/classes/actions/control_object.cc
@@ -1,9 +1,8 @@
 /* control_object.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 11 Jan 2020, 22:31:27 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2015  Trinity Annabelle Quirk
+ * Copyright (C) 2006-2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/actions/move.cc
+++ b/server/classes/actions/move.cc
@@ -1,9 +1,8 @@
 /* move.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 26 Feb 2021, 08:30:17 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2006-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/actions/register.cc
+++ b/server/classes/actions/register.cc
@@ -1,9 +1,8 @@
 /* register.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 15 Feb 2020, 10:20:17 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2006-2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/actions/register.h
+++ b/server/classes/actions/register.h
@@ -1,9 +1,8 @@
 /* register.h                                              -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 07 Aug 2024, 09:15:49 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2024  Trinity Annabelle Quirk
+ * Copyright (C) 2006-2024  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/basesock.cc
+++ b/server/classes/basesock.cc
@@ -1,9 +1,8 @@
 /* basesock.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 02 Oct 2021, 08:49:12 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2007-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/basesock.h
+++ b/server/classes/basesock.h
@@ -1,9 +1,8 @@
 /* basesock.h                                              -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 17 Apr 2018, 07:39:27 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2018  Trinity Annabelle Quirk
+ * Copyright (C) 2007-2018  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/config_data.cc
+++ b/server/classes/config_data.cc
@@ -1,9 +1,8 @@
 /* config_data.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 13 Dec 2020, 22:02:36 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 1998-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/config_data.h
+++ b/server/classes/config_data.h
@@ -1,9 +1,8 @@
 /* config_data.h                                           -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 13 Dec 2020, 21:59:51 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 1998-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/control.cc
+++ b/server/classes/control.cc
@@ -1,9 +1,8 @@
 /* control.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 02 Jul 2019, 08:14:37 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2000-2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/control.h
+++ b/server/classes/control.h
@@ -1,9 +1,8 @@
 /* control.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 13 Dec 2019, 08:43:02 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2000-2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/dgram.cc
+++ b/server/classes/dgram.cc
@@ -1,9 +1,8 @@
 /* dgram.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 02 Oct 2021, 08:52:50 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2007-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/dgram.h
+++ b/server/classes/dgram.h
@@ -1,9 +1,8 @@
 /* dgram.h                                                 -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 14 Jul 2019, 23:43:46 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2007-2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/game_obj.cc
+++ b/server/classes/game_obj.cc
@@ -1,9 +1,8 @@
 /* game_obj.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Sep 2021, 22:37:16 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2000-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/game_obj.h
+++ b/server/classes/game_obj.h
@@ -1,9 +1,8 @@
 /* game_obj.h                                              -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 13 Mar 2021, 09:24:35 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2000-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/geometry.cc
+++ b/server/classes/geometry.cc
@@ -1,9 +1,8 @@
 /* geometry.c
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 26 Sep 2017, 12:58:24 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2017  Trinity Annabelle Quirk
+ * Copyright (C) 2002-2017  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/geometry.h
+++ b/server/classes/geometry.h
@@ -1,9 +1,8 @@
 /* geometry.h                                              -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 14 Dec 2019, 09:43:35 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2002-2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/library.cc
+++ b/server/classes/library.cc
@@ -1,9 +1,8 @@
 /* library.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 27 Dec 2020, 14:14:59 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2014-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/library.h
+++ b/server/classes/library.h
@@ -1,9 +1,8 @@
 /* library.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 24 Dec 2020, 15:39:02 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2014-2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -1,9 +1,8 @@
 /* listensock.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 27 Sep 2021, 08:52:55 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2015-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/listensock.h
+++ b/server/classes/listensock.h
@@ -1,9 +1,8 @@
 /* listensock.h                                            -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Dec 2019, 14:01:15 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2015-2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/log.cc
+++ b/server/classes/log.cc
@@ -1,9 +1,8 @@
 /* log.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 09 Aug 2017, 10:05:10 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2017  Trinity Annabelle Quirk
+ * Copyright (C) 2014-2017  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/log.h
+++ b/server/classes/log.h
@@ -1,6 +1,5 @@
 /* log.h                                                   -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 11 Jul 2014, 10:50:48 trinityquirk
  *
  * Revision IX game server
  * Copyright (C) 2014  Trinity Annabelle Quirk

--- a/server/classes/modules/console.cc
+++ b/server/classes/modules/console.cc
@@ -1,9 +1,8 @@
 /* console.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 02 Oct 2021, 08:54:42 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2014-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/modules/console.h
+++ b/server/classes/modules/console.h
@@ -1,9 +1,8 @@
 /* console.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 07 Dec 2015, 08:39:44 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2015  Trinity Annabelle Quirk
+ * Copyright (C) 2014-2015  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/modules/db.cc
+++ b/server/classes/modules/db.cc
@@ -1,9 +1,8 @@
 /* db.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 02 Oct 2021, 09:06:23 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2014-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/modules/db.h
+++ b/server/classes/modules/db.h
@@ -1,9 +1,8 @@
 /* db.h                                                    -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 23 Dec 2019, 19:40:48 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2014-2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/modules/fdstreambuf.h
+++ b/server/classes/modules/fdstreambuf.h
@@ -1,6 +1,5 @@
 /* fdstreambuf.h                                           -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 06 Nov 2015, 13:36:08 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2015  Trinity Annabelle Quirk

--- a/server/classes/modules/language.cc
+++ b/server/classes/modules/language.cc
@@ -1,6 +1,5 @@
 /* language.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 06 Sep 2015, 12:03:55 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2015  Trinity Annabelle Quirk

--- a/server/classes/modules/language.h
+++ b/server/classes/modules/language.h
@@ -1,9 +1,8 @@
 /* language.h                                              -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 04 Oct 2015, 11:54:19 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2015  Trinity Annabelle Quirk
+ * Copyright (C) 2014-2015  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/modules/r9lua.cc
+++ b/server/classes/modules/r9lua.cc
@@ -1,6 +1,5 @@
 /* r9lua.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 31 Mar 2018, 08:54:21 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2018  Trinity Annabelle Quirk

--- a/server/classes/modules/r9lua.h
+++ b/server/classes/modules/r9lua.h
@@ -1,6 +1,5 @@
 /* r9lua.h                                                 -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 30 Mar 2018, 18:13:52 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2018  Trinity Annabelle Quirk

--- a/server/classes/modules/r9mysql.cc
+++ b/server/classes/modules/r9mysql.cc
@@ -1,9 +1,8 @@
 /* r9mysql.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 02 Oct 2021, 22:16:40 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 1999-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/modules/r9mysql.h
+++ b/server/classes/modules/r9mysql.h
@@ -1,9 +1,8 @@
 /* r9mysql.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 23 Dec 2019, 19:41:01 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2014-2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/modules/r9pgsql.cc
+++ b/server/classes/modules/r9pgsql.cc
@@ -1,9 +1,8 @@
 /* r9pgsql.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 28 Sep 2020, 22:38:18 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 1998-2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/modules/r9pgsql.h
+++ b/server/classes/modules/r9pgsql.h
@@ -1,9 +1,8 @@
 /* r9pgsql.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 23 Dec 2019, 19:41:16 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2014-2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/modules/r9python.cc
+++ b/server/classes/modules/r9python.cc
@@ -1,9 +1,8 @@
 /* r9python.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 24 Feb 2023, 07:48:38 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2023  Trinity Annabelle Quirk
+ * Copyright (C) 2017-2025  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/modules/r9python.h
+++ b/server/classes/modules/r9python.h
@@ -1,9 +1,8 @@
 /* r9python.h                                              -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 12 Jun 2022, 12:44:25 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2017  Trinity Annabelle Quirk
+ * Copyright (C) 2017-2025  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/modules/r9tcl.cc
+++ b/server/classes/modules/r9tcl.cc
@@ -1,9 +1,8 @@
 /* r9tcl.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 01 Apr 2018, 09:37:28 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2018  Trinity Annabelle Quirk
+ * Copyright (C) 1998-2018  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/modules/r9tcl.h
+++ b/server/classes/modules/r9tcl.h
@@ -1,9 +1,8 @@
 /* r9tcl.h                                                 -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 10 Aug 2015, 07:44:38 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2015  Trinity Annabelle Quirk
+ * Copyright (C) 2014-2015  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/motion_pool.cc
+++ b/server/classes/motion_pool.cc
@@ -1,9 +1,8 @@
 /* motion_pool.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 06 Mar 2021, 16:30:25 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2015-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/motion_pool.h
+++ b/server/classes/motion_pool.h
@@ -1,9 +1,8 @@
 /* motion_pool.h                                           -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 21 Jun 2017, 07:45:35 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2017  Trinity Annabelle Quirk
+ * Copyright (C) 2015-2017  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/octree.cc
+++ b/server/classes/octree.cc
@@ -1,9 +1,8 @@
 /* octree.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 02 Oct 2021, 09:20:56 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2000-2025  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/octree.h
+++ b/server/classes/octree.h
@@ -1,9 +1,8 @@
 /* octree.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 05 Nov 2020, 07:26:05 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2000-2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/sockaddr.h
+++ b/server/classes/sockaddr.h
@@ -1,9 +1,8 @@
 /* sockaddr.h                                              -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Aug 2025, 08:02:09 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2015  Trinity Annabelle Quirk
+ * Copyright (C) 2006-2025  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/socket.cc
+++ b/server/classes/socket.cc
@@ -1,9 +1,8 @@
 /* socket.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 07 Aug 2024, 09:14:44 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2024  Trinity Annabelle Quirk
+ * Copyright (C) 2016-2024  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/socket.h
+++ b/server/classes/socket.h
@@ -1,9 +1,8 @@
 /* socket.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 07 Aug 2024, 09:14:18 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2024  Trinity Annabelle Quirk
+ * Copyright (C) 2016-2024  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/stream.cc
+++ b/server/classes/stream.cc
@@ -1,9 +1,8 @@
 /* stream.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 30 Sep 2021, 08:51:01 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2007-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/stream.h
+++ b/server/classes/stream.h
@@ -1,9 +1,8 @@
 /* stream.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 14 Jul 2019, 23:44:17 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2007-2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/thread_pool.h
+++ b/server/classes/thread_pool.h
@@ -1,9 +1,8 @@
 /* thread_pool.h                                           -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 02 Oct 2021, 09:02:12 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2006-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/update_pool.cc
+++ b/server/classes/update_pool.cc
@@ -1,9 +1,8 @@
 /* update_pool.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 13 Mar 2021, 09:23:42 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2021  Trinity Annabelle Quirk
+ * Copyright (C) 2015-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/update_pool.h
+++ b/server/classes/update_pool.h
@@ -1,6 +1,5 @@
 /* update_pool.h                                           -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 12 Nov 2015, 11:18:36 tquirk
  *
  * Revision IX game server
  * Copyright (C) 2015  Trinity Annabelle Quirk

--- a/server/classes/zone.cc
+++ b/server/classes/zone.cc
@@ -1,9 +1,8 @@
 /* zone.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 17 Oct 2020, 22:37:02 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2000-2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/classes/zone.h
+++ b/server/classes/zone.h
@@ -1,9 +1,8 @@
 /* zone.h                                                  -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 10 Feb 2020, 22:53:03 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2000-2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/server.cc
+++ b/server/server.cc
@@ -1,9 +1,8 @@
 /* server.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 02 Oct 2021, 09:00:09 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 1998-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/server.h
+++ b/server/server.h
@@ -1,9 +1,8 @@
 /* server.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 07 Aug 2024, 09:16:10 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2024  Trinity Annabelle Quirk
+ * Copyright (C) 1998-2024  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/signals.cc
+++ b/server/signals.cc
@@ -1,9 +1,8 @@
 /* signals.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 30 Sep 2021, 09:06:28 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 1998-2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/server/signals.h
+++ b/server/signals.h
@@ -1,9 +1,8 @@
 /* signals.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 07 Aug 2024, 09:16:31 tquirk
  *
  * Revision IX game server
- * Copyright (C) 2024  Trinity Annabelle Quirk
+ * Copyright (C) 1998-2024  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/util/r9_keygen.cc
+++ b/util/r9_keygen.cc
@@ -1,9 +1,8 @@
 /* r9_keygen.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 15 Apr 2025, 08:47:26 tquirk
  *
  * Revision IX game utility
- * Copyright (C) 2025  Trinity Annabelle Quirk
+ * Copyright (C) 2019-2025  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License


### PR DESCRIPTION
Having the last updated date/time stamps in every file causes more trouble than it's worth.  Reverts are more painful, merges are more painful, and stashing/restoring is more painful.  It made sense back before we were using version control, but now git keeps track of all that stuff for us.

We also update the copyright years, turning them into a range of years that the file was changed.  We're not counting this commit, because nothing of interest is actually changing.