### PR TITLE
Have octree nodes delete themselves properly

### DIFF
--- a/server/classes/octree.cc
+++ b/server/classes/octree.cc
@@ -335,11 +335,20 @@ void Octree::remove(GameObject *gobj)
             this->octants[octant]->remove(gobj);
         this->objects.erase(gobj);
     }
-    this->leave();
     /* If our subtree doesn't have enough objects to warrant a
      * subtree, delete ourselves.
      */
     if (this->objects.size() < Octree::MAX_LEAF_OBJECTS
         && this->depth > Octree::MIN_DEPTH)
+    {
+        if (this->parent != NULL)
+        {
+            this->parent->enter();
+            this->parent->octants[this->parent_index] = NULL;
+            this->parent->leave();
+        }
         delete this;
+        return;
+    }
+    this->leave();
 }


### PR DESCRIPTION
When an octree node deletes itself, it needs to make sure that there are no dangling references in its parent.