### PR TITLE
Revert "Use Python minimal API"

### DIFF
--- a/server/classes/modules/r9python.h
+++ b/server/classes/modules/r9python.h
@@ -28,7 +28,6 @@
 #ifndef __INC_R9PYTHON_H__
 #define __INC_R9PYTHON_H__
 
-#define Py_LIMITED_API 3
 #include <Python.h>
 
 #include "language.h"
@@ -36,7 +35,7 @@
 class PythonLanguage : public Language
 {
   private:
-    PyInterpreterState *sub_interp;
+    PyThreadState *sub_interp;
 
   public:
     PythonLanguage();


### PR DESCRIPTION
This reverts commit 3021d5f0c6b2715a0d27d4cbf55e9bf00b7c35dd.

It ended up breaking the tests, and isn't actually a problem (yet?).