### PR TITLE
Move socket user deletions into stop methods

### DIFF
--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -261,8 +261,6 @@ listen_socket::~listen_socket()
 
     delete this->send_pool;
     delete this->access_pool;
-
-    this->users.erase(this->users.begin(), this->users.end());
 }
 
 void listen_socket::start(void)
@@ -293,6 +291,10 @@ void listen_socket::stop(void)
 
     this->send_pool->stop();
     this->access_pool->stop();
+
+    for (auto& user : this->users)
+        delete user.second;
+    this->users.clear();
 }
 
 void listen_socket::access_pool_worker(void *arg)

--- a/server/classes/stream.cc
+++ b/server/classes/stream.cc
@@ -98,6 +98,10 @@ void stream_socket::stop(void)
     for (auto& fd : this->fds)
         close(fd.first);
     this->fds.clear();
+    /* Users are deleted in the basesock stop method.  All user
+     * pointers in this->user_fds are invalid at this point.
+     */
+    this->user_fds.clear();
 }
 
 void stream_socket::handle_packet(packet& p, int len, int fd)

--- a/test/t_listensock.cc
+++ b/test/t_listensock.cc
@@ -390,7 +390,6 @@ void test_listen_socket_handle_ack(void)
 
     isnt(bu->timestamp, 0, test + "expected timestamp");
 
-    delete bu;
     delete listen;
     delete addr;
 }
@@ -444,7 +443,6 @@ void test_listen_socket_handle_action(void)
 
     delete (ThreadPool<packet_list> *)action_pool;
     delete go;
-    delete bu;
     delete listen;
     delete zone;
     delete database;
@@ -478,7 +476,6 @@ void test_listen_socket_handle_logout(void)
     is(al.buf.basic.type, TYPE_LGTREQ, test + "expected logout packet");
     is(al.what.logout.who, 123LL, test + "expected userid");
 
-    delete bu;
     delete listen;
     delete addr;
 }

--- a/test/t_listensock_worker.cc
+++ b/test/t_listensock_worker.cc
@@ -56,9 +56,8 @@ void test_reaper_worker(void)
 
     is(listen->send_pool->queue_size() > 0, true,
        test + "expected send queue size");
-    is(listen->users.size(), 1, test + "expected user list size");
+    is(listen->users.size(), 0, test + "expected user list size");
 
-    delete bu;
     delete listen;
     delete addr;
 }


### PR DESCRIPTION
We've had an inconsistent approach to where things in the various socket classes get created and deleted.  We moved socket creation into the `start()` methods, and did improve what got deleted in the `stop()` methods, but we were focused mostly on the various threads that actually made the sockets do their work, and didn't consider the user structures.

Once the socket is closed, none of the user structures should make sense, and that's the right time to remove them.  The listen socket maintains the base user map, so should be the one to clear it.  The stream socket keeps another, so it can delete its own structure.

We also found that the listen socket would leak any users which were logged in at time of stop.  We now delete them.  The stream socket also keeps references to those users in its structures, but once we get to those structures, the contents point to freed memory, and can simply be cleared out.

A couple tests needed tweaking, to reflect things that the sockets now take care of.