### PR TITLE
Add extremely simple collisions

### DIFF
--- a/server/classes/game_obj.cc
+++ b/server/classes/game_obj.cc
@@ -254,6 +254,25 @@ bool GameObject::still_moving(void)
                 || this->rotation != GameObject::no_rotation));
 }
 
+bool GameObject::collide(GameObject *target)
+{
+    if (target == this)
+        return false;
+
+    const glm::dvec3& target_pos = target->get_position();
+
+    if (this->active == true
+        && this->distance_from(target_pos)
+        <= this->geometry->radius + target->geometry->radius)
+    {
+        std::unique_lock lock(this->movement_lock);
+
+        this->movement = -this->movement;
+        return true;
+    }
+    return false;
+}
+
 void GameObject::generate_update_packet(packet& pkt)
 {
     std::shared_lock lock(this->movement_lock);

--- a/server/classes/game_obj.cc
+++ b/server/classes/game_obj.cc
@@ -2,7 +2,7 @@
  *   by Trinity Quirk <tquirk@ymb.net>
  *
  * Revision IX game server
- * Copyright (C) 2000-2021  Trinity Annabelle Quirk
+ * Copyright (C) 2000-2026  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -55,6 +55,8 @@ GameObject::GameObject(Geometry *g, Control *c, uint64_t newid)
     : position(), movement(), look(0.0, 1.0, 0.0),
       orient(1.0, 0.0, 0.0, 0.0), rotation(1.0, 0.0, 0.0, 0.0), movement_lock()
 {
+    if (g == NULL)
+        g = new Geometry();
     this->default_master = this->master = c;
     this->default_geometry = this->geometry = g;
     this->active = true;

--- a/server/classes/game_obj.h
+++ b/server/classes/game_obj.h
@@ -128,6 +128,8 @@ class GameObject
     void move_and_rotate(void);
     bool still_moving(void);
 
+    bool collide(GameObject *);
+
     void generate_update_packet(packet& pkt);
 };
 

--- a/server/classes/geometry.cc
+++ b/server/classes/geometry.cc
@@ -2,7 +2,7 @@
  *   by Trinity Quirk <tquirk@ymb.net>
  *
  * Revision IX game server
- * Copyright (C) 2002-2017  Trinity Annabelle Quirk
+ * Copyright (C) 2002-2026  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -29,13 +29,15 @@
 #include "config_data.h"
 
 Geometry::Geometry()
-    : center()
+    : center(0.0, 0.0, 0.0)
 {
+    this->radius = 0.5;
 }
 
 Geometry::Geometry(const Geometry& geo)
+    : center(geo.center)
 {
-    radius = geo.radius;
+    this->radius = geo.radius;
 }
 
 Geometry::~Geometry()

--- a/server/classes/motion_pool.cc
+++ b/server/classes/motion_pool.cc
@@ -27,8 +27,6 @@
  * movements.
  *
  * Things to do
- *   - The physics library, once we create it, should be a part of this
- *     object, and not the zone as we had originally intended.
  *
  */
 
@@ -70,13 +68,32 @@ void MotionPool::motion_pool_worker(void *arg)
             req->move_and_rotate();
             sector = zone->sector_contains(req->get_position());
             if (sector != NULL)
+            {
                 sector->insert(req);
-            /* else figure out the neighbor that it needs to go to */
-            /*mot->physics->collide(sector, req);*/
+                if (mot->collide(sector, req) || req->still_moving())
+                    mot->push(req);
+            }
+            else
+                /* Should instead figure out the neighbor that it
+                 * needs to go to and make a motion request there.
+                 */
+                continue;
             update_pool->push(req);
 
-            if (req->still_moving())
-                mot->push(req);
         }
     }
+}
+
+bool MotionPool::collide(Octree *sector, GameObject *obj)
+{
+    Octree *subtree = sector->find(obj);
+
+    if (subtree == NULL)
+        return false;
+
+    for (GameObject *target : subtree->get_objects())
+        if (obj->collide(target))
+            return true;
+
+    return false;
 }

--- a/server/classes/motion_pool.cc
+++ b/server/classes/motion_pool.cc
@@ -64,7 +64,7 @@ void MotionPool::motion_pool_worker(void *arg)
         if (req->still_moving())
         {
             sector = zone->sector_contains(req->get_position());
-            if (sector == NULL)
+            if (sector == NULL || !req->still_moving())
                 continue;
             sector->remove(req);
             req->move_and_rotate();

--- a/server/classes/motion_pool.cc
+++ b/server/classes/motion_pool.cc
@@ -29,9 +29,6 @@
  * Things to do
  *   - The physics library, once we create it, should be a part of this
  *     object, and not the zone as we had originally intended.
- *   - Consider whether passing a struct into the worker, composed of
- *     pointers to the motion pool, update pool, and zone, might be
- *     more appropriate.
  *
  */
 
@@ -47,11 +44,6 @@ MotionPool::~MotionPool()
 {
 }
 
-/* We will only use this thread pool in a very specific way, so making
- * the caller handle stuff that it doesn't need to know about is
- * inappropriate.  We'll set the required arg and start things up with
- * the expected function.
- */
 void MotionPool::start(void)
 {
     this->startup_arg = (void *)this;

--- a/server/classes/motion_pool.h
+++ b/server/classes/motion_pool.h
@@ -29,6 +29,7 @@
 
 #include "thread_pool.h"
 #include "game_obj.h"
+#include "octree.h"
 
 class MotionPool : public ThreadPool<GameObject *>
 {
@@ -39,6 +40,8 @@ class MotionPool : public ThreadPool<GameObject *>
     void start(void);
 
     static void motion_pool_worker(void *);
+
+    bool collide(Octree *, GameObject *);
 };
 
 #endif /* __INC_MOTION_POOL_H__ */

--- a/server/classes/octree.cc
+++ b/server/classes/octree.cc
@@ -349,3 +349,19 @@ void Octree::remove(GameObject *gobj)
         }
     }
 }
+
+Octree *Octree::find(GameObject *go)
+{
+    std::shared_lock read_lock(this->lock);
+    if (this->objects.find(go) == this->objects.end())
+        return NULL;
+
+    int octant = this->which_octant(go->get_position());
+    if (this->octants[octant] != NULL)
+    {
+        Octree *result = this->octants[octant]->find(go);
+        if (result != NULL)
+            return result;
+    }
+    return this;
+}

--- a/server/classes/octree.cc
+++ b/server/classes/octree.cc
@@ -350,6 +350,12 @@ void Octree::remove(GameObject *gobj)
     }
 }
 
+Octree::object_set_t Octree::get_objects(void)
+{
+    std::shared_lock read_lock(this->lock);
+    return Octree::object_set_t(this->objects.begin(), this->objects.end());
+}
+
 Octree *Octree::find(GameObject *go)
 {
     std::shared_lock read_lock(this->lock);

--- a/server/classes/octree.cc
+++ b/server/classes/octree.cc
@@ -242,18 +242,17 @@ bool Octree::empty(void)
     return this->objects.empty();
 }
 
-void Octree::build(std::list<GameObject *>& objs)
+void Octree::build(const std::list<GameObject *>& objs)
 {
-    std::set<GameObject *> go_set;
+    Octree::object_set_t go_set;
 
     go_set.insert(objs.begin(), objs.end());
     this->build(go_set);
 }
 
-void Octree::build(std::set<GameObject *>& objs)
+void Octree::build(const Octree::object_set_t& objs)
 {
-    std::set<GameObject *> obj_list[8];
-    std::set<GameObject *>::iterator i;
+    Octree::object_set_t obj_list[8];
     int j;
 
     this->objects.insert(objs.begin(), objs.end());
@@ -262,7 +261,7 @@ void Octree::build(std::set<GameObject *>& objs)
         && (this->depth < Octree::MIN_DEPTH
             || objs.size() > Octree::MAX_LEAF_OBJECTS))
     {
-        for (i = objs.begin(); i != objs.end(); ++i)
+        for (auto i = objs.begin(); i != objs.end(); ++i)
             obj_list[this->which_octant((*i)->get_position())].insert(*i);
 
         for (j = 0; j < 8; ++j)

--- a/server/classes/octree.cc
+++ b/server/classes/octree.cc
@@ -244,8 +244,16 @@ bool Octree::empty(void)
 
 void Octree::build(std::list<GameObject *>& objs)
 {
-    std::list<GameObject *> obj_list[8];
-    std::list<GameObject *>::iterator i;
+    std::set<GameObject *> go_set;
+
+    go_set.insert(objs.begin(), objs.end());
+    this->build(go_set);
+}
+
+void Octree::build(std::set<GameObject *>& objs)
+{
+    std::set<GameObject *> obj_list[8];
+    std::set<GameObject *>::iterator i;
     int j;
 
     this->objects.insert(objs.begin(), objs.end());
@@ -255,7 +263,7 @@ void Octree::build(std::list<GameObject *>& objs)
             || objs.size() > Octree::MAX_LEAF_OBJECTS))
     {
         for (i = objs.begin(); i != objs.end(); ++i)
-            obj_list[this->which_octant((*i)->get_position())].push_back(*i);
+            obj_list[this->which_octant((*i)->get_position())].insert(*i);
 
         for (j = 0; j < 8; ++j)
         {
@@ -314,6 +322,7 @@ void Octree::insert(GameObject *gobj)
                           << " (" << e.code().value() << ")" << std::endl;
                 return;
             }
+            this->octants[octant]->build(this->objects);
             this->octants[octant]->compute_neighbors();
         }
         this->octants[octant]->insert(gobj);

--- a/server/classes/octree.h
+++ b/server/classes/octree.h
@@ -95,6 +95,8 @@ class Octree
     void insert(GameObject *);
     void remove(GameObject *);
 
+    object_set_t get_objects(void);
+
     Octree *find(GameObject *);
 };
 

--- a/server/classes/octree.h
+++ b/server/classes/octree.h
@@ -59,6 +59,8 @@
 class Octree
 {
   public:
+    typedef std::set<GameObject *> object_set_t;
+
     static const int MAX_LEAF_OBJECTS;
     static const int MIN_DEPTH;
     static const int MAX_DEPTH;
@@ -72,7 +74,7 @@ class Octree
     uint8_t parent_index;
     int depth;
 
-    std::set<GameObject *> objects;
+    object_set_t objects;
 
   private:
     inline bool in_octant(const glm::dvec3&);
@@ -88,8 +90,8 @@ class Octree
 
     bool empty(void);
 
-    void build(std::list<GameObject *>&);
-    void build(std::set<GameObject *>&);
+    void build(const std::list<GameObject *>&);
+    void build(const object_set_t&);
     void insert(GameObject *);
     void remove(GameObject *);
 };

--- a/server/classes/octree.h
+++ b/server/classes/octree.h
@@ -2,7 +2,7 @@
  *   by Trinity Quirk <tquirk@ymb.net>
  *
  * Revision IX game server
- * Copyright (C) 2000-2020  Trinity Annabelle Quirk
+ * Copyright (C) 2000-2026  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -89,6 +89,7 @@ class Octree
     bool empty(void);
 
     void build(std::list<GameObject *>&);
+    void build(std::set<GameObject *>&);
     void insert(GameObject *);
     void remove(GameObject *);
 };

--- a/server/classes/octree.h
+++ b/server/classes/octree.h
@@ -94,6 +94,8 @@ class Octree
     void build(const object_set_t&);
     void insert(GameObject *);
     void remove(GameObject *);
+
+    Octree *find(GameObject *);
 };
 
 #endif /* INC_OCTREE_H__ */

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -20,6 +20,7 @@ t_ec
 t_encrypt
 t_font
 t_game_obj
+t_geometry
 t_image
 t_key
 t_library

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -15,6 +15,7 @@ if WANT_SERVER
 	t_dgram \
 	t_dgram_worker \
 	t_game_obj \
+	t_geometry \
 	t_library \
 	t_listensock \
 	t_listensock_worker \
@@ -149,6 +150,10 @@ t_game_obj_SOURCES = t_game_obj.cc \
 	../server/classes/control.cc ../server/classes/control.h \
 	../server/classes/geometry.cc ../server/classes/geometry.h
 t_game_obj_LDADD = $(TAP_LDADD)
+
+t_geometry_SOURCES = t_geometry.cc \
+	../server/classes/geometry.cc ../server/classes/geometry.h
+t_geometry_LDADD = $(TAP_LDADD)
 
 t_library_SOURCES = t_library.cc \
 	../server/classes/library.cc ../server/classes/library.h

--- a/test/t_game_obj.cc
+++ b/test/t_game_obj.cc
@@ -155,7 +155,7 @@ void test_distance(void)
 
     glm::dvec3 pt = {0.0, 0.0, 0.0};
     go->set_position(glm::dvec3(1.0, 0.0, 0.0));
-    is(go->distance_from(pt), 1.0, test + "expected distance");
+    ok(go->distance_from(pt) == 1.0, test + "expected distance");
 
     delete go;
     delete con;
@@ -227,9 +227,41 @@ void test_move_and_rotate(void)
     delete con;
 }
 
+void test_update(void)
+{
+    std::string test = "update: ", st;
+    GameObject *go = NULL;
+    Geometry *geom = new Geometry();
+    Control *con = new Control(1LL, NULL);
+    packet pkt;
+
+    GameObject::reset_max_id();
+
+    go = new GameObject(geom, con, 46LL);
+
+    st = "inactive: ";
+
+    go->deactivate();
+
+    go->generate_update_packet(pkt);
+
+    is(pkt.del.type, TYPE_OBJDEL, test + st + "expected packet type");
+
+    st = "active: ";
+
+    go->activate();
+
+    go->generate_update_packet(pkt);
+
+    is(pkt.pos.type, TYPE_POSUPD, test + st + "expected packet type");
+
+    delete go;
+    delete con;
+}
+
 int main(int argc, char **argv)
 {
-    plan(42);
+    plan(44);
 
     test_create_delete();
     test_clone();
@@ -239,5 +271,6 @@ int main(int argc, char **argv)
     test_distance();
     test_accessors();
     test_move_and_rotate();
+    test_update();
     return exit_status();
 }

--- a/test/t_geometry.cc
+++ b/test/t_geometry.cc
@@ -1,0 +1,52 @@
+#include <tap++.h>
+
+using namespace TAP;
+
+#include "../server/classes/geometry.h"
+
+void test_default_constructor(void)
+{
+    std::string test = "default constructor: ";
+    Geometry *geom = NULL;
+
+    try
+    {
+        geom = new Geometry();
+    }
+    catch (...)
+    {
+        fail(test + "constructor exception");
+    }
+    is(geom->center.x == 0.0, true, test + "expected x value");
+    is(geom->center.y == 0.0, true, test + "expected y value");
+    is(geom->center.z == 0.0, true, test + "expected z value");
+    is(geom->radius == 0.5, true, test + "expected radius");
+
+    delete geom;
+}
+
+void test_copy_constructor(void)
+{
+    std::string test = "default constructor: ";
+    Geometry *geom1 = new Geometry(), *geom2 = NULL;
+
+    geom1->center = {1.0, 2.0, 3.0};
+    geom1->radius = 4.0;
+
+    geom2 = new Geometry(*geom1);
+
+    is(geom2->center == geom1->center, true, test + "expected x value");
+    is(geom2->radius == geom1->radius, true, test + "expected radius");
+
+    delete geom2;
+    delete geom1;
+}
+
+int main(int argc, char **argv)
+{
+    plan(6);
+
+    test_default_constructor();
+    test_copy_constructor();
+    return exit_status();
+}

--- a/test/t_octree.cc
+++ b/test/t_octree.cc
@@ -122,6 +122,10 @@ void test_build(void)
     is(sub->parent_index, 0, test + "expected parent index");
     is(sub->depth, Octree::MAX_DEPTH, test + "expected depth");
 
+    Octree::object_set_t result = tree->get_objects();
+
+    is(result.size(), tree->objects.size(), test + "expected set size");
+
     tree->remove(go4);
     is(tree->objects.find(go4) == tree->objects.end(),
        true,
@@ -148,7 +152,7 @@ void test_build(void)
 
 int main(int argc, char **argv)
 {
-    plan(14);
+    plan(15);
 
     test_create_delete();
     test_build_empty_list();


### PR DESCRIPTION
There is quite a bit of scaffolding we needed to add before we could actually do collisions.  Game objects didn't have geometries by default, and geometries didn't have useful settings.  Octrees didn't build out full subtrees upon insert if they needed to, didn't have the ability to find the leaf node of where an object resided, and didn't have the ability to produce a lock-free list of what was actually in a subtree for a caller.

Once those were done, we had the ability to actually do some calculations.  We decided that the game objects themselves should be the place where those calculations happened, and the motion pool would just direct the checking of which collisions we tested.  It ended up reasonably clean, but will surely get more complicated once we deal with angles of incidence and reflection and object springiness and friction and weight.  You know, like reality.