### PR TITLE
Add better collisions

### DIFF
--- a/server/classes/game_obj.cc
+++ b/server/classes/game_obj.cc
@@ -254,6 +254,12 @@ bool GameObject::still_moving(void)
                 || this->rotation != GameObject::no_rotation));
 }
 
+/* TODO:  This assumes velocities are fairly low, and could miss
+ * collisions between objects which are moving with very high
+ * velocity.  We should project back along a decent quantum (perhaps
+ * scaled by the actual velocity?) to see if there was a collision
+ * along the path at all.
+ */
 bool GameObject::collide(GameObject *target)
 {
     if (target == this)
@@ -265,10 +271,24 @@ bool GameObject::collide(GameObject *target)
         && this->distance_from(target_pos)
         <= this->geometry->radius + target->geometry->radius)
     {
+        const glm::dvec3& target_move = target->get_movement();
         std::unique_lock lock(this->movement_lock);
+        const glm::dvec3 relative_vel = this->movement - target_move;
+        const glm::dvec3 normal = glm::normalize(target_pos - this->position);
+        const glm::dvec3 tangent = glm::normalize(
+            relative_vel - target_pos - this->position
+        );
+        double vel_normal = glm::dot(relative_vel, normal);
+        double vel_tangent = glm::dot(relative_vel, tangent);
 
-        this->movement = -this->movement;
-        return true;
+        this->movement = -normal * this->geometry->restitution
+            + (vel_tangent / 2 * tangent * (1 - this->geometry->friction));
+        lock.unlock();
+        target->set_movement(
+            normal * target->geometry->restitution
+            + (-vel_tangent / 2 * tangent * (1 - target->geometry->friction))
+        );
+        return this->movement != GameObject::no_movement;
     }
     return false;
 }

--- a/server/classes/geometry.cc
+++ b/server/classes/geometry.cc
@@ -1,4 +1,4 @@
-/* geometry.c
+/* geometry.cc
  *   by Trinity Quirk <tquirk@ymb.net>
  *
  * Revision IX game server
@@ -26,18 +26,23 @@
  */
 
 #include "geometry.h"
-#include "config_data.h"
 
 Geometry::Geometry()
     : center(0.0, 0.0, 0.0)
 {
     this->radius = 0.5;
+    this->mass = 1.0;
+    this->restitution = 0.75;
+    this->friction = 0.25;
 }
 
 Geometry::Geometry(const Geometry& geo)
     : center(geo.center)
 {
     this->radius = geo.radius;
+    this->mass = geo.mass;
+    this->restitution = geo.restitution;
+    this->friction = geo.friction;
 }
 
 Geometry::~Geometry()

--- a/server/classes/geometry.h
+++ b/server/classes/geometry.h
@@ -2,7 +2,7 @@
  *   by Trinity Quirk <tquirk@ymb.net>
  *
  * Revision IX game server
- * Copyright (C) 2002-2019  Trinity Annabelle Quirk
+ * Copyright (C) 2002-2026  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -48,7 +48,7 @@ class Geometry
 
     std::vector< std::vector<sequence_element> > sequences;*/
     glm::dvec3 center;
-    double radius;
+    double radius, mass, restitution, friction;
 
   public:
     Geometry();

--- a/server/classes/motion_pool.cc
+++ b/server/classes/motion_pool.cc
@@ -92,8 +92,15 @@ bool MotionPool::collide(Octree *sector, GameObject *obj)
         return false;
 
     for (GameObject *target : subtree->get_objects())
+    {
+        bool already_moving = target->still_moving();
         if (obj->collide(target))
-            return true;
+        {
+            if (!already_moving && target->still_moving())
+                this->push(target);
 
+            return true;
+        }
+    }
     return false;
 }

--- a/server/classes/octree.cc
+++ b/server/classes/octree.cc
@@ -37,11 +37,6 @@
  * can know when the truncation is happening.
  *
  * Things to do
- *   - Make the neighbor-finder breadth-first, not depth-first as it
- *     is now.  Half the neighbors are going to end up NULL the way it
- *     stands.
- *   - Consider if the neighbors are really necessary.  If not, we can
- *     save a bunch of computation by getting rid of all of it.
  *   - Consider how we would do a move operation.  As things stand
  *     right now, we need to do an remove/insert pair, which may
  *     involve a bunch of possibly unnecessary memory deallocation and
@@ -64,7 +59,7 @@ const int Octree::MAX_LEAF_OBJECTS = 3;
 const int Octree::MIN_DEPTH = 5;
 const int Octree::MAX_DEPTH = 10;
 
-/* Orientation of octants and neighbors:
+/* Orientation of octants:
 
      +---------+--------+
      |\         \        \
@@ -85,20 +80,6 @@ const int Octree::MAX_DEPTH = 10;
            \ |         |    4   |                    |  \
             \|         |        |                    ~   ~
              +---------+--------+                    3    5
-
-Neighbor 0: if (index & 4 == 0) (parent->neighbor->octant[index - 4])
-            else (index + 4)
-Neighbor 1: if (index & 4) (parent->neighbor->octant[index + 4])
-            else (index - 4)
-Neighbor 2: if (index & 2 == 0) (parent->neighbor->octant[index - 2])
-            else (index + 2)
-Neighbor 3: if (index & 2) (parent->neighbor->octant[index + 2])
-            else (index - 2)
-Neighbor 4: if (index & 1 == 0) (parent->neighbor->octant[index - 1])
-            else (index + 1)
-Neighbor 5: if (index & 1) (parent->neighbor->octant[index + 1])
-            else (index - 1)
-
 */
 
 bool Octree::in_octant(const glm::dvec3& p)
@@ -113,15 +94,6 @@ int Octree::which_octant(const glm::dvec3& p)
     return ((p[0] < this->center_point[0] ? 0 : 4)
             | (p[1] < this->center_point[1] ? 0 : 2)
             | (p[2] < this->center_point[2] ? 0 : 1));
-}
-
-Octree *Octree::neighbor_test(int neigh, int oct)
-{
-    if (this->parent->neighbor[neigh] == NULL)
-        return NULL;
-    if (this->parent->neighbor[neigh]->octants[oct] == NULL)
-        return this->parent->neighbor[neigh];
-    return this->parent->neighbor[neigh]->octants[oct];
 }
 
 glm::dvec3 Octree::octant_min(int oct)
@@ -144,53 +116,6 @@ glm::dvec3 Octree::octant_max(int oct)
     return mx;
 }
 
-void Octree::compute_neighbors(void)
-{
-    int i;
-
-    /* The root octant has no neighbors, and they have already been set
-     * to NULL in the constructor, so that's a no-op.
-     */
-    if (this->parent != NULL)
-    {
-        if (this->parent_index & 4)
-        {
-            this->neighbor[0] = this->neighbor_test(0, this->parent_index - 4);
-            this->neighbor[1] = this->parent->octants[this->parent_index - 4];
-        }
-        else
-        {
-            this->neighbor[0] = this->parent->octants[this->parent_index + 4];
-            this->neighbor[1] = this->neighbor_test(1, this->parent_index + 4);
-        }
-
-        if (this->parent_index & 2)
-        {
-            this->neighbor[2] = this->neighbor_test(2, this->parent_index - 2);
-            this->neighbor[3] = this->parent->octants[this->parent_index - 2];
-        }
-        else
-        {
-            this->neighbor[2] = this->parent->octants[this->parent_index + 2];
-            this->neighbor[3] = this->neighbor_test(3, this->parent_index + 2);
-        }
-
-        if (this->parent_index & 1)
-        {
-            this->neighbor[4] = this->neighbor_test(4, this->parent_index - 1);
-            this->neighbor[5] = this->parent->octants[this->parent_index - 1];
-        }
-        else
-        {
-            this->neighbor[4] = this->parent->octants[this->parent_index + 1];
-            this->neighbor[5] = this->neighbor_test(5, this->parent_index + 1);
-        }
-    }
-    for (i = 0; i < 8; ++i)
-        if (this->octants[i] != NULL)
-            this->octants[i]->compute_neighbors();
-}
-
 Octree::Octree(Octree *parent,
                glm::dvec3& min,
                glm::dvec3& max,
@@ -200,7 +125,6 @@ Octree::Octree(Octree *parent,
 {
     this->parent = parent;
     memset(this->octants, 0, sizeof(Octree *) * 8);
-    memset(this->neighbor, 0, sizeof(Octree *) * 6);
     this->parent_index = index;
     if (this->parent != NULL)
         this->depth = this->parent->depth + 1;
@@ -216,21 +140,10 @@ Octree::~Octree()
         if (this->octants[i] != NULL)
             delete this->octants[i];
 
-    /* It is possible that we may only remove part of a tree, so make
-     * any neighbors point to our parent, and our parent point to
-     * nothing, for consistency.  If we're the root of the tree, it
-     * doesn't matter, of course.
-     */
-    if (this->parent != NULL)
-    {
-        /* Detach from our parent so the neighbor recalc will ignore us */
-        if (this->parent->octants[this->parent_index] == this)
-            this->parent->octants[this->parent_index] = NULL;
-        /* Reset our neighbors' neighbor pointers */
-        for (i = 0; i < 6; ++i)
-            if (this->neighbor[i] != NULL)
-                this->neighbor[i]->compute_neighbors();
-    }
+    if (this->parent != NULL
+        && this->parent->octants[this->parent_index] == this)
+        this->parent->octants[this->parent_index] = NULL;
+
     /* Allowing the map destructor to clear itself out will delete all
      * the things in the map... not what we want.
      */
@@ -286,13 +199,6 @@ void Octree::build(const Octree::object_set_t& objs)
             }
         }
     }
-    /* I don't think we can do this during creation because of the way
-     * we do the higher-numbered octants' check, and the fact that the
-     * target octants will not have been created yet, though I'll look
-     * into it.
-     */
-    if (this->depth == 0)
-        this->compute_neighbors();
 }
 
 void Octree::insert(GameObject *gobj)
@@ -322,7 +228,6 @@ void Octree::insert(GameObject *gobj)
                 return;
             }
             this->octants[octant]->build(this->objects);
-            this->octants[octant]->compute_neighbors();
         }
         this->octants[octant]->insert(gobj);
     }
@@ -344,6 +249,7 @@ void Octree::remove(GameObject *gobj)
         {
             if (this->parent != NULL)
                 this->parent->octants[this->parent_index] = NULL;
+            write_lock.unlock();
             delete this;
             return;
         }

--- a/server/classes/octree.h
+++ b/server/classes/octree.h
@@ -23,9 +23,7 @@
  *
  * We are not going to subdivide anything - it's more work than we may
  * ever need to do.  For the time being, we'll just classify based on
- * the center of the object.  We may eventually need to test our
- * neighbors' contents for a full collision test, but this'll be
- * lightweight for now.
+ * the center of the object.
  *
  * We need to have a max tree height too, but I don't know what range
  * is realistic.  Perhaps 10 or so might be a good start?  We might
@@ -70,7 +68,7 @@ class Octree
 
   public:
     glm::dvec3 min_point, center_point, max_point;
-    Octree *parent, *octants[8], *neighbor[6];
+    Octree *parent, *octants[8];
     uint8_t parent_index;
     int depth;
 
@@ -79,10 +77,8 @@ class Octree
   private:
     inline bool in_octant(const glm::dvec3&);
     inline int which_octant(const glm::dvec3&);
-    inline Octree *neighbor_test(int neigh, int oct);
     inline glm::dvec3 octant_min(int oct);
     inline glm::dvec3 octant_max(int oct);
-    void compute_neighbors(void);
 
   public:
     Octree(Octree *, glm::dvec3&, glm::dvec3&, uint8_t);

--- a/test/t_game_obj.cc
+++ b/test/t_game_obj.cc
@@ -227,6 +227,32 @@ void test_move_and_rotate(void)
     delete con;
 }
 
+void test_collide(void)
+{
+    std::string test = "collide: ", st;
+    GameObject *go1 = new GameObject(NULL, NULL, 93LL);
+    GameObject *go2 = new GameObject(NULL, NULL, 94LL);
+
+    st = "miss: ";
+    go1->set_position(glm::dvec3(123.0, 123.0, 123.0));
+    go1->set_movement(glm::dvec3(1.0, 0.0, 0.0));
+    go2->set_position(glm::dvec3(234.0, 234.0, 234.0));
+
+    bool result = go1->collide(go2);
+
+    not_ok(result, test + st + "expected result");
+
+    st = "hit: ";
+    go2->set_position(glm::dvec3(123.5, 123.0, 123.0));
+
+    result = go1->collide(go2);
+
+    ok(result, test + st + "expected result");
+
+    delete go2;
+    delete go1;
+}
+
 void test_update(void)
 {
     std::string test = "update: ", st;
@@ -261,7 +287,7 @@ void test_update(void)
 
 int main(int argc, char **argv)
 {
-    plan(44);
+    plan(46);
 
     test_create_delete();
     test_clone();
@@ -271,6 +297,7 @@ int main(int argc, char **argv)
     test_distance();
     test_accessors();
     test_move_and_rotate();
+    test_collide();
     test_update();
     return exit_status();
 }

--- a/test/t_geometry.cc
+++ b/test/t_geometry.cc
@@ -21,6 +21,9 @@ void test_default_constructor(void)
     is(geom->center.y == 0.0, true, test + "expected y value");
     is(geom->center.z == 0.0, true, test + "expected z value");
     is(geom->radius == 0.5, true, test + "expected radius");
+    is(geom->mass == 1.0, true, test + "expected mass");
+    is(geom->restitution == 0.75, true, test + "expected restitution");
+    is(geom->friction == 0.25, true, test + "expected friction");
 
     delete geom;
 }
@@ -32,11 +35,19 @@ void test_copy_constructor(void)
 
     geom1->center = {1.0, 2.0, 3.0};
     geom1->radius = 4.0;
+    geom1->mass = 10.0;
+    geom1->restitution = 0.2;
+    geom1->friction = 0.8;
 
     geom2 = new Geometry(*geom1);
 
     is(geom2->center == geom1->center, true, test + "expected x value");
     is(geom2->radius == geom1->radius, true, test + "expected radius");
+    is(geom2->mass == geom1->mass, true, test + "expected mass");
+    is(geom2->restitution == geom1->restitution,
+       true,
+       test + "expected restitution");
+    is(geom2->friction == geom1->friction, true, test + "expected friction");
 
     delete geom2;
     delete geom1;
@@ -44,7 +55,7 @@ void test_copy_constructor(void)
 
 int main(int argc, char **argv)
 {
-    plan(6);
+    plan(12);
 
     test_default_constructor();
     test_copy_constructor();

--- a/test/t_motion_pool.cc
+++ b/test/t_motion_pool.cc
@@ -103,11 +103,53 @@ void test_operate(void)
     delete std::clog.rdbuf(orig_rdbuf);
 }
 
+void test_collide(void)
+{
+    std::string test = "collide: ", st;
+    glm::dvec3 min(0.0, 0.0, 0.0), max(1000.0, 1000.0, 1000.0);
+    sector = new Octree(NULL, min, max, 1);
+    motion_pool = new MotionPool("t_motion", 1);
+    GameObject *go1 = new GameObject(NULL, NULL, 9876LL);
+    GameObject *go2 = new GameObject(NULL, NULL, 9877LL);
+
+    go1->set_position(glm::dvec3(234.0, 234.0, 234.0));
+    go2->set_position(glm::dvec3(123.0, 123.0, 123.0));
+    sector->insert(go2);
+
+    st = "not present: ";
+    motion_pool->collide(sector, go1);
+
+    is(motion_pool->queue_size(), 0, test + st + "expected queue length");
+
+    st = "miss: ";
+    sector->insert(go1);
+    motion_pool->collide(sector, go1);
+
+    is(motion_pool->queue_size(), 0, test + st + "expected queue length");
+
+    st = "hit: ";
+    sector->remove(go1);
+    go1->set_position(glm::dvec3(123.5, 123.0, 123.0));
+    sector->insert(go1);
+
+    motion_pool->collide(sector, go1);
+
+    isnt(motion_pool->queue_size(), 0, test + st + "expected queue length");
+
+    sector->remove(go2);
+    sector->remove(go1);
+    delete go2;
+    delete go1;
+    delete sector;
+    delete motion_pool;
+}
+
 int main(int argc, char **argv)
 {
-    plan(18);
+    plan(21);
 
     test_start_stop();
     test_operate();
+    test_collide();
     return exit_status();
 }


### PR DESCRIPTION
We've previously added the simplest collisions ever, and we want to make them a bit more realistic.  Objects now bounce off each other.  We add some motion parameters to the game objects - mass, friction, restitution (bounciness) - and use some of them in the calculations.

I'm not convinced that the tangent calculations are correct here, but at the velocities we can deal with right now, they're in the neighborhood.  I'd love some help, but this is likely always going to be a solo project.

We also remove the octrees' neighbor pointers.  They are the cause of a lot of segfaults, and we don't actually use them for anything, so they can go for now.  They're in version control if we really need them back.