### PR TITLE
Yet more socket cleanups

### DIFF
--- a/server/classes/dgram.cc
+++ b/server/classes/dgram.cc
@@ -144,9 +144,11 @@ void dgram_socket::handle_packet(packet& p, int len, Sockaddr *sa)
         if (this->socks.find(sa) != this->socks.end())
         {
             user = this->socks[sa];
-            if (!user->decrypt_packet(p) || !ntoh_packet(&p, len))
+            if (!user->decrypt_packet(p))
                 return;
         }
+        if (!ntoh_packet(&p, len))
+            return;
         packet_handlers[p.basic.type](this, p, user, sa);
     }
 }

--- a/server/classes/dgram.cc
+++ b/server/classes/dgram.cc
@@ -81,13 +81,12 @@ void dgram_socket::connect_user(base_user *bu, access_list& al)
 
 void dgram_socket::disconnect_user(base_user *bu)
 {
+    if (this->user_socks.find(bu->userid) != this->user_socks.end())
     {
-        std::unique_lock lock(this->user_mutex);
-        if (this->user_socks.find(bu->userid) != this->user_socks.end())
-        {
-            this->socks.erase(this->user_socks[bu->userid]);
-            this->user_socks.erase(bu->userid);
-        }
+        Sockaddr *sa = this->user_socks[bu->userid];
+        this->socks.erase(sa);
+        this->user_socks.erase(bu->userid);
+        delete sa;
     }
 
     this->listen_socket::disconnect_user(bu);

--- a/server/classes/dgram.cc
+++ b/server/classes/dgram.cc
@@ -161,7 +161,7 @@ void dgram_socket::handle_login(listen_socket *s, packet& p,
      * because we can't return objects out of an abstract factory
      * function by value.  They must be by pointer.
      */
-    al.what.login.who.dgram = ((Sockaddr *)sa)->clone();
+    al.what.login.who.dgram = build_sockaddr(*((Sockaddr *)sa)->sockaddr());
     s->access_pool->push(al);
 }
 

--- a/server/classes/dgram.cc
+++ b/server/classes/dgram.cc
@@ -136,13 +136,18 @@ void dgram_socket::dgram_listen_worker(void *arg)
 
 void dgram_socket::handle_packet(packet& p, int len, Sockaddr *sa)
 {
+    base_user *user = NULL;
+
     if (packet_handlers.find(p.basic.type) != packet_handlers.end())
     {
         std::shared_lock lock(this->user_mutex);
-        if (this->socks.find(sa) != this->socks.end()
-            && this->socks[sa]->decrypt_packet(p)
-            && ntoh_packet(&p, len))
-            packet_handlers[p.basic.type](this, p, this->socks[sa], sa);
+        if (this->socks.find(sa) != this->socks.end())
+        {
+            user = this->socks[sa];
+            if (!user->decrypt_packet(p) || !ntoh_packet(&p, len))
+                return;
+        }
+        packet_handlers[p.basic.type](this, p, user, sa);
     }
 }
 

--- a/server/classes/dgram.cc
+++ b/server/classes/dgram.cc
@@ -73,11 +73,8 @@ void dgram_socket::start(void)
 
 void dgram_socket::connect_user(base_user *bu, access_list& al)
 {
-    {
-        std::unique_lock lock(this->user_mutex);
-        this->socks[al.what.login.who.dgram] = bu;
-        this->user_socks[bu->userid] = al.what.login.who.dgram;
-    }
+    this->socks[al.what.login.who.dgram] = bu;
+    this->user_socks[bu->userid] = al.what.login.who.dgram;
 
     this->listen_socket::connect_user(bu, al);
 }

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -416,6 +416,7 @@ void listen_socket::login_user(access_list& p)
     if (userid == 0LL)
         return;
 
+    std::unique_lock lock(this->user_mutex);
     if (this->users.find(userid) != this->users.end())
     {
         /* This is going to be a race with the reaper thread. */
@@ -470,10 +471,7 @@ void listen_socket::connect_user(base_user *bu, access_list& al)
 {
     uint64_t obj_id = 0LL;
 
-    {
-        std::unique_lock lock(this->user_mutex);
-        this->users[bu->userid] = bu;
-    }
+    this->users[bu->userid] = bu;
     if (bu->default_slave != NULL)
     {
         bu->default_slave->activate();

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -344,6 +344,12 @@ void listen_socket::reaper_worker(listen_socket *ls)
         now = time(NULL);
         link_dead = now - listen_socket::LINK_DEAD_TIMEOUT;
         sleepy = now - listen_socket::PING_TIMEOUT;
+
+        std::unique_lock lock(ls->user_mutex);
+
+        /* We use this weird not-for loop so we don't invalidate our
+         * iterator when we delete an entry that we're pointing to.
+         */
         i = ls->users.begin();
         while (i != ls->users.end())
         {
@@ -419,7 +425,6 @@ void listen_socket::login_user(access_list& p)
     std::unique_lock lock(this->user_mutex);
     if (this->users.find(userid) != this->users.end())
     {
-        /* This is going to be a race with the reaper thread. */
         this->users[userid]->pending_logout = false;
         return;
     }
@@ -483,7 +488,6 @@ void listen_socket::connect_user(base_user *bu, access_list& al)
 
 void listen_socket::disconnect_user(base_user *bu)
 {
-    std::unique_lock lock(this->user_mutex);
     this->users.erase(bu->userid);
     delete bu;
 }

--- a/server/classes/sockaddr.h
+++ b/server/classes/sockaddr.h
@@ -109,8 +109,6 @@ class Sockaddr
             snprintf(s, sizeof(s), "%s:%hu", this->ntop(), this->port());
             return std::string(s);
         }
-
-    virtual Sockaddr *clone(void) = 0;
 };
 
 class Sockaddr_in : public Sockaddr
@@ -202,8 +200,6 @@ class Sockaddr_in : public Sockaddr
     uint16_t port(void) const { return ntohs(this->sin->sin_port); }
     struct sockaddr *sockaddr(void) { return (struct sockaddr *)this->sin; }
     size_t size(void) const { return sizeof(struct sockaddr_in); }
-
-    Sockaddr *clone(void) { return new Sockaddr_in(*this); }
 };
 
 /* A couple functions to be able to handle IPV6 addresses easily:
@@ -314,8 +310,6 @@ class Sockaddr_in6 : public Sockaddr
     uint16_t port(void) const { return ntohs(this->sin6->sin6_port); }
     struct sockaddr *sockaddr(void) { return (struct sockaddr *)this->sin6; }
     size_t size(void) const { return sizeof(struct sockaddr_in6); }
-
-    Sockaddr *clone(void) { return new Sockaddr_in6(*this); }
 };
 
 class Sockaddr_un : public Sockaddr
@@ -399,8 +393,6 @@ class Sockaddr_un : public Sockaddr
     struct sockaddr *sockaddr(void) { return (struct sockaddr *)this->sun; }
     size_t size(void) const { return sizeof(struct sockaddr_un); }
     std::string str(void) { return this->ntop(); }
-
-    Sockaddr *clone(void) { return new Sockaddr_un(*this); }
 };
 
 inline Sockaddr *build_sockaddr(struct sockaddr& s)

--- a/server/classes/stream.cc
+++ b/server/classes/stream.cc
@@ -106,19 +106,18 @@ void stream_socket::stop(void)
 
 void stream_socket::handle_packet(packet& p, int len, int fd)
 {
-    auto handler = packet_handlers.find(p.basic.type);
-    auto found = this->fds.find(fd);
-    base_user *u = NULL;
+    base_user *user = NULL;
 
-    if (handler != packet_handlers.end())
+    if (packet_handlers.find(p.basic.type) != packet_handlers.end())
     {
-        if (found != this->fds.end())
+        std::shared_lock lock(this->user_mutex);
+        if (this->fds.find(fd) != this->fds.end())
         {
-            u = found->second;
-            if (!u->decrypt_packet(p) || !ntoh_packet(&p, len))
+            user = this->fds[fd];
+            if (!user->decrypt_packet(p) || !ntoh_packet(&p, len)))
                 return;
         }
-        (handler->second)(this, p, u, &fd);
+        packet_handlers[p.basic.type](this, p, user, &fd);
     }
 }
 

--- a/server/classes/stream.cc
+++ b/server/classes/stream.cc
@@ -114,9 +114,11 @@ void stream_socket::handle_packet(packet& p, int len, int fd)
         if (this->fds.find(fd) != this->fds.end())
         {
             user = this->fds[fd];
-            if (!user->decrypt_packet(p) || !ntoh_packet(&p, len)))
+            if (!user->decrypt_packet(p))
                 return;
         }
+        if (!ntoh_packet(&p, len))
+            return;
         packet_handlers[p.basic.type](this, p, user, &fd);
     }
 }

--- a/server/classes/stream.cc
+++ b/server/classes/stream.cc
@@ -143,18 +143,15 @@ void stream_socket::connect_user(base_user *bu, access_list& al)
 
 void stream_socket::disconnect_user(base_user *bu)
 {
+    if (this->user_fds.find(bu->userid) != this->user_fds.end())
     {
-        std::unique_lock lock(this->user_mutex);
-        if (this->user_fds.find(bu->userid) != this->user_fds.end())
-        {
-            int fd = this->user_fds[bu->userid];
-            close(fd);
-            FD_CLR(fd, &this->master_readfs);
-            if (fd + 1 == this->max_fd)
-                --this->max_fd;
-            this->fds.erase(fd);
-            this->user_fds.erase(bu->userid);
-        }
+        int fd = this->user_fds[bu->userid];
+        close(fd);
+        FD_CLR(fd, &this->master_readfs);
+        if (fd + 1 == this->max_fd)
+            --this->max_fd;
+        this->fds.erase(fd);
+        this->user_fds.erase(bu->userid);
     }
 
     this->listen_socket::disconnect_user(bu);

--- a/server/classes/stream.cc
+++ b/server/classes/stream.cc
@@ -135,11 +135,8 @@ void stream_socket::handle_login(listen_socket *s, packet& p,
 
 void stream_socket::connect_user(base_user *bu, access_list& al)
 {
-    {
-        std::unique_lock lock(this->user_mutex);
-        this->fds[al.what.login.who.stream] = bu;
-        this->user_fds[bu->userid] = al.what.login.who.stream;
-    }
+    this->fds[al.what.login.who.stream] = bu;
+    this->user_fds[bu->userid] = al.what.login.who.stream;
 
     this->listen_socket::connect_user(bu, al);
 }

--- a/test/t_sockaddr.cc
+++ b/test/t_sockaddr.cc
@@ -44,8 +44,6 @@ class fake_Sockaddr : public Sockaddr
     virtual const char *hostname(void) {return "host";};
     virtual int family(void) const {return AF_INET;};
     virtual uint16_t port(void) const {return 42;};
-
-    Sockaddr *clone(void) { return new fake_Sockaddr(*this); }
 };
 
 void test_sockaddr_blank_constructor(void)
@@ -424,19 +422,6 @@ void test_sockaddr_in_size(void)
     delete sa_in;
 }
 
-void test_sockaddr_in_clone(void)
-{
-    std::string test = "sockaddr_in clone: ";
-    Sockaddr_in *sa_in = new Sockaddr_in;
-    Sockaddr_in *cloned_sa_in = dynamic_cast<Sockaddr_in *>(sa_in->clone());
-
-    ok(*sa_in == *cloned_sa_in, test + "objects equal");
-    ok(sa_in != cloned_sa_in, test + "objects distinct");
-
-    delete cloned_sa_in;
-    delete sa_in;
-}
-
 void test_sockaddr_in_factory(void)
 {
     std::string test = "sockaddr_in factory: ";
@@ -711,19 +696,6 @@ void test_sockaddr_in6_size(void)
     delete sa_in6;
 }
 
-void test_sockaddr_in6_clone(void)
-{
-    std::string test = "sockaddr_in6 clone: ";
-    Sockaddr_in6 *sa_in6 = new Sockaddr_in6;
-    Sockaddr_in6 *cloned_sa_in6 = dynamic_cast<Sockaddr_in6 *>(sa_in6->clone());
-
-    ok(*sa_in6 == *cloned_sa_in6, test + "objects equal");
-    ok(sa_in6 != cloned_sa_in6, test + "objects distinct");
-
-    delete cloned_sa_in6;
-    delete sa_in6;
-}
-
 void test_sockaddr_in6_factory(void)
 {
     std::string test = "sockaddr_in6 factory: ";
@@ -948,19 +920,6 @@ void test_sockaddr_un_size(void)
     delete sa_un;
 }
 
-void test_sockaddr_un_clone(void)
-{
-    std::string test = "sockaddr_un clone: ";
-    Sockaddr_un *sa_un = new Sockaddr_un;
-    Sockaddr_un *cloned_sa_un = dynamic_cast<Sockaddr_un *>(sa_un->clone());
-
-    ok(*sa_un == *cloned_sa_un, test + "objects equal");
-    ok(sa_un != cloned_sa_un, test + "objects distinct");
-
-    delete cloned_sa_un;
-    delete sa_un;
-}
-
 void test_sockaddr_un_factory(void)
 {
     std::string test = "sockaddr_un factory: ";
@@ -982,7 +941,7 @@ void test_sockaddr_un_factory(void)
 
 int main(int argc, char **argv)
 {
-    plan(119);
+    plan(113);
 
     test_sockaddr_blank_constructor();
     test_sockaddr_copy_constructor();
@@ -1004,7 +963,6 @@ int main(int argc, char **argv)
     test_sockaddr_in_port();
     test_sockaddr_in_sockaddr();
     test_sockaddr_in_size();
-    test_sockaddr_in_clone();
     test_sockaddr_in_factory();
 
     test_sockaddr_in6_blank_constructor();
@@ -1018,7 +976,6 @@ int main(int argc, char **argv)
     test_sockaddr_in6_port();
     test_sockaddr_in6_sockaddr();
     test_sockaddr_in6_size();
-    test_sockaddr_in6_clone();
     test_sockaddr_in6_factory();
 
     test_sockaddr_un_blank_constructor();
@@ -1032,7 +989,6 @@ int main(int argc, char **argv)
     test_sockaddr_un_port();
     test_sockaddr_un_sockaddr();
     test_sockaddr_un_size();
-    test_sockaddr_un_clone();
     test_sockaddr_un_factory();
     return exit_status();
 }


### PR DESCRIPTION
We managed to break datagram sockets with our last merge; that's what we get for relying solely on unit tests, and not doing any functional testing.  Turned out it was the `Sockaddr::clone` methods we added.  We also regressed logins, which we have fixed.

The new changes here are mostly locking related, moving locks around to close race conditions, and simplifying subclass locking for login and logout.  We also made sure all packets, even login packets that probably don't need network-to-host conversion, are so converted before dispatching.

And we tried everything out for real before making a PR this time.  It is working as expected.