### PR TITLE
Listensock visibility

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: Set up environment
       run: |
-        sudo apt-get purge firefox php8.3 php8.3-cgi php8.3-cli php8.3-fpm || true
+        sudo apt-get purge firefox php8.3 php8.3-cgi php8.3-cli php8.3-fpm snapd || true
         sudo apt-get autoremove
         sudo apt-get update
         sudo apt-get upgrade -y

--- a/server/classes/dgram.cc
+++ b/server/classes/dgram.cc
@@ -153,7 +153,10 @@ void dgram_socket::handle_login(listen_socket *s, packet& p,
                                 base_user *u, void *sa)
 {
     access_list al;
+    dgram_socket *ds = dynamic_cast<dgram_socket *>(s);
 
+    if (ds == NULL)
+        return;
     memcpy(&al.buf, &p, sizeof(login_request));
     /* sa gets cleaned up at the end of packet handling, but we need
      * to keep the object around for our user maps.  This is not an
@@ -162,7 +165,7 @@ void dgram_socket::handle_login(listen_socket *s, packet& p,
      * function by value.  They must be by pointer.
      */
     al.what.login.who.dgram = build_sockaddr(*((Sockaddr *)sa)->sockaddr());
-    s->access_pool->push(al);
+    ds->access_pool->push(al);
 }
 
 void dgram_socket::dgram_send_worker(void *arg)

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -491,3 +491,10 @@ void listen_socket::disconnect_user(base_user *bu)
     this->users.erase(bu->userid);
     delete bu;
 }
+
+void listen_socket::iter_users(std::function<void(base_user *)> func)
+{
+    std::shared_lock lock(this->user_mutex);
+    for (auto& user : this->users)
+        func(user.second);
+}

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -198,7 +198,7 @@ void base_user::send_server_key(uint8_t *pubkey, size_t key_sz)
                                                 sizeof(pkt.buf.key.pubkey)));
     memcpy(pkt.buf.key.iv, this->iv, R9_SYMMETRIC_IV_BUF_SZ);
     pkt.who = this;
-    this->parent->send_pool->push(pkt);
+    this->parent->send(pkt);
 }
 
 void base_user::send_ping(void)
@@ -209,7 +209,7 @@ void base_user::send_ping(void)
     pkt.buf.basic.version = R9_PROTO_VER;
     pkt.buf.basic.sequence = this->sequence++;
     pkt.who = this;
-    this->parent->send_pool->push(pkt);
+    this->parent->send(pkt);
 }
 
 void base_user::send_ack(uint8_t req,
@@ -227,7 +227,7 @@ void base_user::send_ack(uint8_t req,
     pkt.buf.ack.misc[2] = misc2;
     pkt.buf.ack.misc[3] = misc3;
     pkt.who = this;
-    this->parent->send_pool->push(pkt);
+    this->parent->send(pkt);
 }
 
 listen_socket::listen_socket()
@@ -497,4 +497,9 @@ void listen_socket::iter_users(std::function<void(base_user *)> func)
     std::shared_lock lock(this->user_mutex);
     for (auto& user : this->users)
         func(user.second);
+}
+
+void listen_socket::send(packet_list& p)
+{
+    this->send_pool->push(p);
 }

--- a/server/classes/listensock.h
+++ b/server/classes/listensock.h
@@ -133,10 +133,8 @@ class listen_socket : public basesock
     std::map<uint64_t, base_user *> users;
 
     ThreadPool<packet_list> *send_pool;
-  public:
     ThreadPool<access_list> *access_pool;
 
-  protected:
     listen_socket();
     void init(void);
 

--- a/server/classes/listensock.h
+++ b/server/classes/listensock.h
@@ -29,6 +29,7 @@
 #define __INC_LISTENSOCK_H__
 
 #include <map>
+#include <functional>
 
 #include <proto/proto.h>
 #include <proto/encrypt.h>
@@ -123,8 +124,8 @@ class listen_socket : public basesock
     bool reaper_started;
     std::thread reaper_thread;
 
-  public:
     std::shared_mutex user_mutex;
+  public:
     std::map<uint64_t, base_user *> users;
 
     typedef std::map<uint64_t, base_user *>::iterator users_iterator;
@@ -158,6 +159,8 @@ class listen_socket : public basesock
 
     virtual void connect_user(base_user *, access_list&);
     virtual void disconnect_user(base_user *);
+
+    void iter_users(std::function<void(base_user *)>);
 };
 
 #endif /* __INC_LISTENSOCK_H__ */

--- a/server/classes/listensock.h
+++ b/server/classes/listensock.h
@@ -119,6 +119,11 @@ class listen_socket : public basesock
     static const int PING_TIMEOUT = 30;
     static const int LINK_DEAD_TIMEOUT = 75;
 
+    typedef std::map<uint64_t, base_user *>::iterator users_iterator;
+
+    typedef void (*packet_handler)(listen_socket *, packet&,
+                                   base_user *, void *);
+
   protected:
     int reap_timeout;
     bool reaper_started;
@@ -127,13 +132,8 @@ class listen_socket : public basesock
     std::shared_mutex user_mutex;
     std::map<uint64_t, base_user *> users;
 
-  public:
-    typedef std::map<uint64_t, base_user *>::iterator users_iterator;
-
-    typedef void (*packet_handler)(listen_socket *, packet&,
-                                   base_user *, void *);
-
     ThreadPool<packet_list> *send_pool;
+  public:
     ThreadPool<access_list> *access_pool;
 
   protected:
@@ -161,6 +161,7 @@ class listen_socket : public basesock
     virtual void disconnect_user(base_user *);
 
     void iter_users(std::function<void(base_user *)>);
+    void send(packet_list&);
 };
 
 #endif /* __INC_LISTENSOCK_H__ */

--- a/server/classes/listensock.h
+++ b/server/classes/listensock.h
@@ -125,9 +125,9 @@ class listen_socket : public basesock
     std::thread reaper_thread;
 
     std::shared_mutex user_mutex;
-  public:
     std::map<uint64_t, base_user *> users;
 
+  public:
     typedef std::map<uint64_t, base_user *>::iterator users_iterator;
 
     typedef void (*packet_handler)(listen_socket *, packet&,

--- a/server/classes/stream.cc
+++ b/server/classes/stream.cc
@@ -127,10 +127,13 @@ void stream_socket::handle_login(listen_socket *s, packet& p,
                                  base_user *u, void *fdp)
 {
     access_list al;
+    stream_socket *ss = dynamic_cast<stream_socket *>(s);
 
+    if (ss == NULL)
+        return;
     memcpy(&al.buf, &p, sizeof(login_request));
     al.what.login.who.stream = *((int *)fdp);
-    s->access_pool->push(al);
+    ss->access_pool->push(al);
 }
 
 void stream_socket::connect_user(base_user *bu, access_list& al)

--- a/server/classes/update_pool.cc
+++ b/server/classes/update_pool.cc
@@ -57,14 +57,12 @@ void UpdatePool::update_pool_worker(void *arg)
         /* Figure out who to send it to */
         /* Send to EVERYONE (for now) */
         for (auto sock : sockets)
-        {
-            std::shared_lock lock(sock->user_mutex);
-            for (auto& user : sock->users)
-            {
-                pkt.who = user.second;
-                pkt.buf.pos.sequence = user.second->sequence++;
-                sock->send_pool->push(pkt);
-            }
-        }
+            sock->iter_users(
+                [&](base_user *user) {
+                    pkt.who = user;
+                    pkt.buf.pos.sequence = user->sequence++;
+                    sock->send_pool->push(pkt);
+                }
+            );
     }
 }

--- a/server/classes/update_pool.cc
+++ b/server/classes/update_pool.cc
@@ -61,7 +61,7 @@ void UpdatePool::update_pool_worker(void *arg)
                 [&](base_user *user) {
                     pkt.who = user;
                     pkt.buf.pos.sequence = user->sequence++;
-                    sock->send_pool->push(pkt);
+                    sock->send(pkt);
                 }
             );
     }

--- a/test/mock_listensock.h
+++ b/test/mock_listensock.h
@@ -26,6 +26,8 @@ class fake_listen_socket : public listen_socket
     /* Shouldn't need to mock the access_pool_worker static method,
      * since the fake start/stop methods won't do anything.
      */
+
+    using listen_socket::users;
 };
 
 #endif /* __INC_MOCK_LISTENSOCK_H__ */

--- a/test/mock_listensock.h
+++ b/test/mock_listensock.h
@@ -28,6 +28,7 @@ class fake_listen_socket : public listen_socket
      */
 
     using listen_socket::users;
+    using listen_socket::send_pool;
 };
 
 #endif /* __INC_MOCK_LISTENSOCK_H__ */

--- a/test/t_dgram.cc
+++ b/test/t_dgram.cc
@@ -20,6 +20,8 @@ class test_dgram_socket : public dgram_socket
             if (stop_error == true)
                 throw std::runtime_error("oh noes!");
         };
+
+    using listen_socket::users;
 };
 
 void test_create_delete(void)
@@ -73,7 +75,7 @@ void test_connect_user(void)
 {
     std::string test = "connect_user: ";
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
-    dgram_socket *dgs = new dgram_socket(addr);
+    test_dgram_socket *dgs = new test_dgram_socket(addr);
 
     is(dgs->users.size(), 0, test + "expected user list size");
     is(dgs->socks.size(), 0, test + "expected socks size");
@@ -104,7 +106,7 @@ void test_disconnect_user(void)
 {
     std::string test = "disconnect_user: ";
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
-    dgram_socket *dgs = new dgram_socket(addr);
+    test_dgram_socket *dgs = new test_dgram_socket(addr);
     fake_base_user *bu = new fake_base_user(123LL);
     struct sockaddr_in sin;
 
@@ -159,7 +161,7 @@ void test_handle_packet(void)
 {
     std::string test = "handle_packet: ";
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
-    dgram_socket *dgs = new dgram_socket(addr);
+    test_dgram_socket *dgs = new test_dgram_socket(addr);
     fake_base_user *bu = new fake_base_user(123LL);
     struct sockaddr_in sin;
 
@@ -189,7 +191,7 @@ void test_handle_login(void)
 {
     std::string test = "handle_login: ";
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
-    dgram_socket *dgs = new dgram_socket(addr);
+    test_dgram_socket *dgs = new test_dgram_socket(addr);
     Sockaddr *sa = addr->sockaddr();
 
     packet p;

--- a/test/t_dgram.cc
+++ b/test/t_dgram.cc
@@ -23,6 +23,7 @@ class test_dgram_socket : public dgram_socket
 
     using listen_socket::users;
     using listen_socket::send_pool;
+    using listen_socket::access_pool;
 };
 
 void test_create_delete(void)

--- a/test/t_dgram.cc
+++ b/test/t_dgram.cc
@@ -22,6 +22,7 @@ class test_dgram_socket : public dgram_socket
         };
 
     using listen_socket::users;
+    using listen_socket::send_pool;
 };
 
 void test_create_delete(void)

--- a/test/t_dgram_worker.cc
+++ b/test/t_dgram_worker.cc
@@ -111,6 +111,15 @@ void test_listen_worker(void)
     delete addr;
 }
 
+class test_dgram_socket : public dgram_socket
+{
+  public:
+    test_dgram_socket(Addrinfo *a) : dgram_socket(a) {};
+    ~test_dgram_socket() {};
+
+    using dgram_socket::users;
+};
+
 /* Send queue test
  *
  * 3 packet_list elements in the send queue:
@@ -127,7 +136,7 @@ void test_send_worker(void)
     pkey_to_public_key(config.key.priv_key, config.key.pub_key, R9_PUBKEY_SZ);
 
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
-    dgram_socket *dgs = new dgram_socket(addr);
+    test_dgram_socket *dgs = new test_dgram_socket(addr);
     fake_base_user *bu = new fake_base_user(123LL);
     bu->parent = (listen_socket *)dgs;
 

--- a/test/t_dgram_worker.cc
+++ b/test/t_dgram_worker.cc
@@ -118,6 +118,7 @@ class test_dgram_socket : public dgram_socket
     ~test_dgram_socket() {};
 
     using dgram_socket::users;
+    using dgram_socket::send_pool;
 };
 
 /* Send queue test

--- a/test/t_listensock.cc
+++ b/test/t_listensock.cc
@@ -34,6 +34,7 @@ class fake_listen_socket : public listen_socket
     virtual ~fake_listen_socket() {};
 
     using listen_socket::users;
+    using listen_socket::send_pool;
 };
 
 void test_base_user_create_delete(void)

--- a/test/t_listensock.cc
+++ b/test/t_listensock.cc
@@ -30,7 +30,10 @@ class fake_listen_socket : public listen_socket
 {
   public:
     fake_listen_socket(void) : listen_socket() {};
+    fake_listen_socket(Addrinfo *a) : listen_socket(a) {};
     virtual ~fake_listen_socket() {};
+
+    using listen_socket::users;
 };
 
 void test_base_user_create_delete(void)
@@ -319,11 +322,11 @@ void test_listen_socket_create_delete(void)
 {
     std::string test = "listen_socket create/delete: ";
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
-    listen_socket *listen;
+    fake_listen_socket *listen;
 
     try
     {
-        listen = new listen_socket(addr);
+        listen = new fake_listen_socket(addr);
     }
     catch (...)
     {
@@ -341,9 +344,7 @@ void test_listen_socket_start_stop(void)
 {
     std::string test = "listen_socket start/stop: ";
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
-    listen_socket *listen;
-
-    listen = new listen_socket(addr);
+    fake_listen_socket *listen = new fake_listen_socket(addr);
 
     try
     {
@@ -375,7 +376,7 @@ void test_listen_socket_handle_ack(void)
 {
     std::string test = "listen_socket handle_ack: ";
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
-    listen_socket *listen = new listen_socket(addr);
+    fake_listen_socket *listen = new fake_listen_socket(addr);
     fake_base_user *bu = new fake_base_user(123LL);
 
     listen->users[bu->userid] = bu;
@@ -400,7 +401,7 @@ void test_listen_socket_handle_action(void)
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
     database = new fake_DB("a", 0, "b", "c", "d");
     zone = new fake_Zone(1000, 1, database);
-    listen_socket *listen = new listen_socket(addr);
+    fake_listen_socket *listen = new fake_listen_socket(addr);
     fake_base_user *bu = new fake_base_user(123LL);
     GameObject *go = new GameObject(NULL, bu);
 
@@ -453,7 +454,7 @@ void test_listen_socket_handle_logout(void)
 {
     std::string test = "listen_socket handle_logout: ";
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
-    listen_socket *listen = new listen_socket(addr);
+    fake_listen_socket *listen = new fake_listen_socket(addr);
     fake_base_user *bu = new fake_base_user(123LL);
 
     listen->users[bu->userid] = bu;
@@ -495,7 +496,7 @@ void test_listen_socket_login_no_user(void)
     strncpy(access.buf.log.charname, "bob", 4);
 
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
-    listen_socket *listen = new listen_socket(addr);
+    fake_listen_socket *listen = new fake_listen_socket(addr);
 
     is(listen->users.size(), 0, test + "expected user list size");
 
@@ -523,7 +524,7 @@ void test_listen_socket_login_already(void)
     strncpy(access.buf.log.username, "howdy", 6);
 
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
-    listen_socket *listen = new listen_socket(addr);
+    fake_listen_socket *listen = new fake_listen_socket(addr);
 
     fake_base_user *bu = new fake_base_user(123LL);
     bu->pending_logout = true;
@@ -560,7 +561,7 @@ void test_listen_socket_login_no_access(void)
     strncpy(access.buf.log.charname, "blah", 5);
 
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
-    listen_socket *listen = new listen_socket(addr);
+    fake_listen_socket *listen = new fake_listen_socket(addr);
 
     is(listen->users.size(), 0, test + "expected user list size");
 
@@ -602,7 +603,7 @@ void test_listen_socket_login(void)
     is(result, R9_PUBKEY_SZ, test + "expected pubkey string size");
 
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
-    listen_socket *listen = new listen_socket(addr);
+    fake_listen_socket *listen = new fake_listen_socket(addr);
 
     is(listen->users.size(), 0, test + "expected user list size");
 
@@ -625,7 +626,7 @@ void test_listen_socket_logout(void)
 {
     std::string test = "listen_socket logout: ";
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
-    listen_socket *listen = new listen_socket(addr);
+    fake_listen_socket *listen = new fake_listen_socket(addr);
 
     fake_base_user *bu = new fake_base_user(123LL);
     bu->parent = listen;
@@ -647,7 +648,7 @@ void test_listen_socket_connect_user(void)
 {
     std::string test = "listen_socket connect_user: ";
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
-    listen_socket *listen = new listen_socket(addr);
+    fake_listen_socket *listen = new fake_listen_socket(addr);
 
     fake_base_user *bu = new fake_base_user(123LL);
     bu->parent = listen;
@@ -672,7 +673,7 @@ void test_listen_socket_disconnect_user(void)
 {
     std::string test = "listen_socket disconnect_user: ";
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
-    listen_socket *listen = new listen_socket(addr);
+    fake_listen_socket *listen = new fake_listen_socket(addr);
 
     fake_base_user *bu = new fake_base_user(123LL);
     bu->parent = listen;

--- a/test/t_listensock.cc
+++ b/test/t_listensock.cc
@@ -35,6 +35,7 @@ class fake_listen_socket : public listen_socket
 
     using listen_socket::users;
     using listen_socket::send_pool;
+    using listen_socket::access_pool;
 };
 
 void test_base_user_create_delete(void)

--- a/test/t_listensock_worker.cc
+++ b/test/t_listensock_worker.cc
@@ -20,6 +20,7 @@ class test_listen_socket : public listen_socket
     using listen_socket::reap_timeout;
     using listen_socket::users;
     using listen_socket::send_pool;
+    using listen_socket::access_pool;
 };
 
 void test_reaper_worker(void)

--- a/test/t_listensock_worker.cc
+++ b/test/t_listensock_worker.cc
@@ -18,6 +18,7 @@ class test_listen_socket : public listen_socket
     test_listen_socket(Addrinfo *a) : listen_socket(a) {};
     virtual ~test_listen_socket() {};
     using listen_socket::reap_timeout;
+    using listen_socket::users;
 };
 
 void test_reaper_worker(void)
@@ -74,7 +75,7 @@ void test_access_worker(void)
     check_authentication_result = 0LL;
 
     Addrinfo *addr = new Addrinfo(DGRAM, "localhost", "8765");
-    listen_socket *listen = new test_listen_socket(addr);
+    test_listen_socket *listen = new test_listen_socket(addr);
 
     access_list req;
 

--- a/test/t_listensock_worker.cc
+++ b/test/t_listensock_worker.cc
@@ -19,6 +19,7 @@ class test_listen_socket : public listen_socket
     virtual ~test_listen_socket() {};
     using listen_socket::reap_timeout;
     using listen_socket::users;
+    using listen_socket::send_pool;
 };
 
 void test_reaper_worker(void)

--- a/test/t_stream.cc
+++ b/test/t_stream.cc
@@ -20,6 +20,7 @@ class test_stream_socket : public stream_socket
 {
   public:
     using stream_socket::users;
+    using stream_socket::send_pool;
     using stream_socket::sock;
     using stream_socket::max_fd;
     using stream_socket::readfs;

--- a/test/t_stream.cc
+++ b/test/t_stream.cc
@@ -19,6 +19,7 @@ bool read_nothing = false, read_bad_packet = false;
 class test_stream_socket : public stream_socket
 {
   public:
+    using stream_socket::users;
     using stream_socket::sock;
     using stream_socket::max_fd;
     using stream_socket::readfs;

--- a/test/t_stream.cc
+++ b/test/t_stream.cc
@@ -21,6 +21,7 @@ class test_stream_socket : public stream_socket
   public:
     using stream_socket::users;
     using stream_socket::send_pool;
+    using stream_socket::access_pool;
     using stream_socket::sock;
     using stream_socket::max_fd;
     using stream_socket::readfs;

--- a/test/t_stream_worker.cc
+++ b/test/t_stream_worker.cc
@@ -17,6 +17,7 @@ class test_stream_socket : public stream_socket
 {
   public:
     using stream_socket::users;
+    using stream_socket::send_pool;
     using stream_socket::max_fd;
     using stream_socket::readfs;
     using stream_socket::master_readfs;

--- a/test/t_stream_worker.cc
+++ b/test/t_stream_worker.cc
@@ -16,6 +16,7 @@ int write_stage = 0;
 class test_stream_socket : public stream_socket
 {
   public:
+    using stream_socket::users;
     using stream_socket::max_fd;
     using stream_socket::readfs;
     using stream_socket::master_readfs;

--- a/test/t_update_pool.cc
+++ b/test/t_update_pool.cc
@@ -27,7 +27,7 @@ class fake_SendPool : public ThreadPool<packet_list>
 void test_operate(void)
 {
     std::string test = "operate: ";
-    listen_socket *sock;
+    fake_listen_socket *sock;
     UpdatePool *pool;
     fake_SendPool *send_pool = new fake_SendPool("t_send", 1);
     GameObject *go = new GameObject(NULL, NULL, 12345LL);


### PR DESCRIPTION
A lot of the listensock members are public, which shouldn't need to be the case.  Some are resolved by adding a couple methods, and some are just some tweaks to the objects and their descendents.  A lot of test objects that need tweaking.