### PR TITLE
Use lambdas for iterating octree contents

### DIFF
--- a/server/classes/motion_pool.cc
+++ b/server/classes/motion_pool.cc
@@ -91,16 +91,16 @@ bool MotionPool::collide(Octree *sector, GameObject *obj)
     if (subtree == NULL)
         return false;
 
-    for (GameObject *target : subtree->get_objects())
-    {
-        bool already_moving = target->still_moving();
-        if (obj->collide(target))
-        {
-            if (!already_moving && target->still_moving())
-                this->push(target);
-
-            return true;
+    return subtree->iter_collisions(
+        [&](GameObject *target) -> bool {
+            bool already_moving = target->still_moving();
+            if (obj->collide(target))
+            {
+                if (!already_moving && target->still_moving())
+                    this->push(target);
+                return true;
+            }
+            return false;
         }
-    }
-    return false;
+    );
 }

--- a/server/classes/octree.cc
+++ b/server/classes/octree.cc
@@ -256,10 +256,13 @@ void Octree::remove(GameObject *gobj)
     }
 }
 
-Octree::object_set_t Octree::get_objects(void)
+bool Octree::iter_collisions(std::function<bool(GameObject *)> func)
 {
     std::shared_lock read_lock(this->lock);
-    return Octree::object_set_t(this->objects.begin(), this->objects.end());
+    for (auto& obj : this->objects)
+        if (func(obj))
+            return true;
+    return false;
 }
 
 Octree *Octree::find(GameObject *go)

--- a/server/classes/octree.h
+++ b/server/classes/octree.h
@@ -49,6 +49,7 @@
 #include <list>
 #include <set>
 #include <shared_mutex>
+#include <functional>
 
 #include <glm/vec3.hpp>
 
@@ -91,7 +92,7 @@ class Octree
     void insert(GameObject *);
     void remove(GameObject *);
 
-    object_set_t get_objects(void);
+    bool iter_collisions(std::function<bool(GameObject *)>);
 
     Octree *find(GameObject *);
 };

--- a/test/t_octree.cc
+++ b/test/t_octree.cc
@@ -122,10 +122,6 @@ void test_build(void)
     is(sub->parent_index, 0, test + "expected parent index");
     is(sub->depth, Octree::MAX_DEPTH, test + "expected depth");
 
-    Octree::object_set_t result = tree->get_objects();
-
-    is(result.size(), tree->objects.size(), test + "expected set size");
-
     tree->remove(go4);
     is(tree->objects.find(go4) == tree->objects.end(),
        true,
@@ -152,7 +148,7 @@ void test_build(void)
 
 int main(int argc, char **argv)
 {
-    plan(15);
+    plan(14);
 
     test_create_delete();
     test_build_empty_list();


### PR DESCRIPTION
When we're iterating for a collision, we currently take a copy of the contents of an octree, which has a number of drawbacks:

- There is no lock, so the contents can change from the original to the copy.
- There is a lot of memory allocation and copying and deallocation, even if it's on the stack, that simply doesn't need to happen.

In 7cce99e5, we pulled some of the listen_socket's public members to be protected inside the class, by providing a method to iterate over a given internal list under lock.  We used lambdas, which are a perfect application in our case here.

We drop the object-list-copying method in favor of a new `iter_collisions` method, which takes a lambda.  We do move a tiny bit of the collision logic from the motion pool here, i.e. we return immediately with `true` if there is a collision, and if there is none, we return `false` at the end of the loop.  It's not a huge pile of logic, but it is something to consider.

There may be future instances in which we want to iterate over the objects list in some other way, which is why we chose the specific name that we did for the new method.  If we needed to overload something generic like `iter_objects`, varying signatures, particularly return types, could cause funkiness.