### PR TITLE
Turn raw ID values into distinct types

### DIFF
--- a/proto/proto.h
+++ b/proto/proto.h
@@ -77,6 +77,8 @@
 #define ACCESS_MOVE 3        /* Move-around-in access (normal access) */
 #define ACCESS_MDFY 4        /* Modify access */
 
+typedef uint64_t userid_t;
+
 /* For testing what type of packet it really is, plus a few of the basic
  * elements.
  */

--- a/proto/proto.h
+++ b/proto/proto.h
@@ -78,6 +78,7 @@
 #define ACCESS_MDFY 4        /* Modify access */
 
 typedef uint64_t userid_t;
+typedef uint64_t charid_t;
 
 /* For testing what type of packet it really is, plus a few of the basic
  * elements.

--- a/proto/proto.h
+++ b/proto/proto.h
@@ -79,6 +79,7 @@
 
 typedef uint64_t userid_t;
 typedef uint64_t charid_t;
+typedef uint64_t objid_t;
 
 /* For testing what type of packet it really is, plus a few of the basic
  * elements.
@@ -122,11 +123,11 @@ typedef struct action_request_tag
     uint8_t type;
     uint8_t version;        /* protocol version number */
     uint64_t sequence;      /* timestamp / sequence number */
-    uint64_t object_id;
+    objid_t object_id;
     uint16_t action_id;
     uint8_t power_level;
     uint64_t x_pos_source, y_pos_source, z_pos_source;
-    uint64_t dest_object_id;
+    objid_t dest_object_id;
     int64_t x_pos_dest, y_pos_dest, z_pos_dest;
 } __attribute__ ((__packed__))
 action_request;
@@ -149,7 +150,7 @@ typedef struct position_update_tag
     uint8_t type;
     uint8_t version;        /* protocol version number */
     uint64_t sequence;      /* timestamp / sequence number */
-    uint64_t object_id;
+    objid_t object_id;
     uint16_t frame_number;
     /* We may consider adding the sector vector back in here */
     uint64_t x_pos, y_pos, z_pos;
@@ -186,7 +187,7 @@ typedef struct object_delete_tag
     uint8_t type;
     uint8_t version;        /* protocol version number */
     uint64_t sequence;      /* timestamp / sequence number */
-    uint64_t object_id;
+    objid_t object_id;
 } __attribute__ ((__packed__))
 object_delete;
 

--- a/server/classes/action_pool.cc
+++ b/server/classes/action_pool.cc
@@ -137,7 +137,7 @@ void ActionPool::execute_action(base_user *user, action_request& req)
 
     if (i != this->actions.end()
         && j != user->actions.end()
-        && user->slave->get_object_id() == req.object_id)
+        && user->slave->object_id == req.object_id)
     {
         /* If it's not valid on this server, it should at least have
          * a default.

--- a/server/classes/actions/control_object.cc
+++ b/server/classes/actions/control_object.cc
@@ -53,8 +53,7 @@ int action_control_object(GameObject *source,
     {
         /* Figure out if the player actually has access to the target */
         if ((access_type
-             = database->check_authorization(src->userid,
-                                             target->get_object_id()))
+             = database->check_authorization(src->userid, target->object_id))
             != ACCESS_NONE)
         {
             if (target->connect(src))

--- a/server/classes/control.cc
+++ b/server/classes/control.cc
@@ -29,7 +29,7 @@
 #include "control.h"
 #include "thread_pool.h"
 
-Control::Control(uint64_t userid, GameObject *slave)
+Control::Control(userid_t userid, GameObject *slave)
 {
     this->userid = userid;
     this->default_slave = this->slave = slave;

--- a/server/classes/control.h
+++ b/server/classes/control.h
@@ -51,12 +51,12 @@ class Control
     typedef std::unordered_map<uint16_t, skill_level> skills_map;
     typedef skills_map::iterator skills_iterator;
 
-    uint64_t userid;
+    userid_t userid;
     GameObject *default_slave, *slave;
     skills_map actions;
 
   public:
-    Control(uint64_t, GameObject *);
+    Control(userid_t, GameObject *);
     virtual ~Control();
 
     virtual bool operator<(const Control&) const;

--- a/server/classes/dgram.h
+++ b/server/classes/dgram.h
@@ -56,7 +56,7 @@ class dgram_socket : public listen_socket
 {
   public:
     std::map<Sockaddr *, base_user *, less_sockaddr> socks;
-    std::map<uint64_t, Sockaddr *> user_socks;
+    std::map<userid_t, Sockaddr *> user_socks;
 
   public:
     dgram_socket(Addrinfo *);

--- a/server/classes/game_obj.cc
+++ b/server/classes/game_obj.cc
@@ -39,7 +39,7 @@
 glm::dvec3 GameObject::no_movement(0.0, 0.0, 0.0);
 glm::dquat GameObject::no_rotation(1.0, 0.0, 0.0, 0.0);
 
-GameObject::GameObject(Geometry *g, Control *c, uint64_t newid)
+GameObject::GameObject(Geometry *g, Control *c, objid_t newid)
     : position(), movement(), look(0.0, 1.0, 0.0),
       orient(1.0, 0.0, 0.0, 0.0), rotation(1.0, 0.0, 0.0, 0.0), movement_lock()
 {
@@ -69,7 +69,7 @@ GameObject *GameObject::clone(void) const
     return new GameObject(new_geom, this->default_master, this->id_value);
 }
 
-uint64_t GameObject::get_object_id(void) const
+objid_t GameObject::get_object_id(void) const
 {
     return this->id_value;
 }

--- a/server/classes/game_obj.cc
+++ b/server/classes/game_obj.cc
@@ -41,14 +41,14 @@ glm::dquat GameObject::no_rotation(1.0, 0.0, 0.0, 0.0);
 
 GameObject::GameObject(Geometry *g, Control *c, objid_t newid)
     : position(), movement(), look(0.0, 1.0, 0.0),
-      orient(1.0, 0.0, 0.0, 0.0), rotation(1.0, 0.0, 0.0, 0.0), movement_lock()
+      orient(1.0, 0.0, 0.0, 0.0), rotation(1.0, 0.0, 0.0, 0.0), movement_lock(),
+      object_id(newid)
 {
     if (g == NULL)
         g = new Geometry();
     this->default_master = this->master = c;
     this->default_geometry = this->geometry = g;
     this->active = true;
-    this->id_value = newid;
     gettimeofday(&this->last_updated, NULL);
 }
 
@@ -66,12 +66,7 @@ GameObject *GameObject::clone(void) const
      * new copy for the new object.
      */
     Geometry *new_geom = new Geometry(*this->default_geometry);
-    return new GameObject(new_geom, this->default_master, this->id_value);
-}
-
-objid_t GameObject::get_object_id(void) const
-{
-    return this->id_value;
+    return new GameObject(new_geom, this->default_master, this->object_id);
 }
 
 bool GameObject::connect(Control *con)
@@ -275,7 +270,7 @@ void GameObject::generate_update_packet(packet& pkt)
     {
         pkt.del.type = TYPE_OBJDEL;
         pkt.del.version = R9_PROTO_VER;
-        pkt.del.object_id = this->id_value;
+        pkt.del.object_id = this->object_id;
     }
     else
     {
@@ -285,7 +280,7 @@ void GameObject::generate_update_packet(packet& pkt)
 
         pkt.pos.type = TYPE_POSUPD;
         pkt.pos.version = R9_PROTO_VER;
-        pkt.pos.object_id = this->id_value;
+        pkt.pos.object_id = this->object_id;
         pkt.pos.x_pos = (uint64_t)pos.x;
         pkt.pos.y_pos = (uint64_t)pos.y;
         pkt.pos.z_pos = (uint64_t)pos.z;

--- a/server/classes/game_obj.cc
+++ b/server/classes/game_obj.cc
@@ -31,25 +31,13 @@
 #include <algorithm>
 #include <sstream>
 #include <system_error>
+#include <mutex>
 
 #include "game_obj.h"
 #include "zone.h"
 
-std::mutex GameObject::max_mutex;
-uint64_t GameObject::max_id_value = 0LL;
-
 glm::dvec3 GameObject::no_movement(0.0, 0.0, 0.0);
 glm::dquat GameObject::no_rotation(1.0, 0.0, 0.0, 0.0);
-
-uint64_t GameObject::reset_max_id(void)
-{
-    uint64_t val;
-
-    std::scoped_lock lock(GameObject::max_mutex);
-    val = GameObject::max_id_value;
-    GameObject::max_id_value = (uint64_t)0;
-    return val;
-}
 
 GameObject::GameObject(Geometry *g, Control *c, uint64_t newid)
     : position(), movement(), look(0.0, 1.0, 0.0),
@@ -60,19 +48,6 @@ GameObject::GameObject(Geometry *g, Control *c, uint64_t newid)
     this->default_master = this->master = c;
     this->default_geometry = this->geometry = g;
     this->active = true;
-
-    {
-        std::scoped_lock lock(GameObject::max_mutex);
-        if (newid == 0LL)
-            newid = GameObject::max_id_value++;
-        else
-            /* This clause is mostly for recreating an object from some
-             * saved state.
-             */
-            GameObject::max_id_value = std::max(GameObject::max_id_value,
-                                                newid + 1);
-    }
-
     this->id_value = newid;
     gettimeofday(&this->last_updated, NULL);
 }
@@ -91,7 +66,7 @@ GameObject *GameObject::clone(void) const
      * new copy for the new object.
      */
     Geometry *new_geom = new Geometry(*this->default_geometry);
-    return new GameObject(new_geom, this->default_master);
+    return new GameObject(new_geom, this->default_master, this->id_value);
 }
 
 uint64_t GameObject::get_object_id(void) const

--- a/server/classes/game_obj.h
+++ b/server/classes/game_obj.h
@@ -39,7 +39,6 @@
 #else
 #include <set>
 #endif /* STD_UNORDERED_SET_WORKS */
-#include <mutex>
 #include <shared_mutex>
 
 #include <glm/vec3.hpp>
@@ -68,9 +67,6 @@ class GameObject
     typedef int attribute;
 
   private:
-    static std::mutex max_mutex;
-    static uint64_t max_id_value;
-
     static glm::dvec3 no_movement;
     static glm::dquat no_rotation;
 
@@ -97,9 +93,7 @@ class GameObject
     Control *master;
 
   public:
-    static uint64_t reset_max_id(void);
-
-    GameObject(Geometry *, Control *, uint64_t = 0LL);
+    GameObject(Geometry *, Control *, uint64_t);
     ~GameObject();
 
     GameObject *clone(void) const;

--- a/server/classes/game_obj.h
+++ b/server/classes/game_obj.h
@@ -61,7 +61,7 @@ class GameObject
     }
     nature;
 
-    typedef std::unordered_map<uint64_t, GameObject *> objects_map;
+    typedef std::unordered_map<objid_t, GameObject *> objects_map;
     typedef objects_map::iterator objects_iterator;
 
     typedef int attribute;
@@ -70,7 +70,7 @@ class GameObject
     static glm::dvec3 no_movement;
     static glm::dquat no_rotation;
 
-    /* const */ uint64_t id_value;
+    /* const */ objid_t id_value;
     Geometry *default_geometry;
     Control *default_master;
 
@@ -93,12 +93,12 @@ class GameObject
     Control *master;
 
   public:
-    GameObject(Geometry *, Control *, uint64_t);
+    GameObject(Geometry *, Control *, objid_t);
     ~GameObject();
 
     GameObject *clone(void) const;
 
-    uint64_t get_object_id(void) const;
+    objid_t get_object_id(void) const;
 
     bool connect(Control *);
     void disconnect(Control *);

--- a/server/classes/game_obj.h
+++ b/server/classes/game_obj.h
@@ -70,7 +70,10 @@ class GameObject
     static glm::dvec3 no_movement;
     static glm::dquat no_rotation;
 
-    /* const */ objid_t id_value;
+  public:
+    const objid_t object_id;
+
+  private:
     Geometry *default_geometry;
     Control *default_master;
 
@@ -97,8 +100,6 @@ class GameObject
     ~GameObject();
 
     GameObject *clone(void) const;
-
-    objid_t get_object_id(void) const;
 
     bool connect(Control *);
     void disconnect(Control *);

--- a/server/classes/geometry.h
+++ b/server/classes/geometry.h
@@ -23,7 +23,6 @@
  * other kind of object) for the game system.
  *
  * Things to do
- *   - Consider how we want to represent our sequences.
  *   - Consider how we want to represent our bounding volumes.  From the
  *   looks of things, we're going to attempt a two-level bounding operation:
  *   first level is a bounding sphere, since it's easy and small, and the
@@ -40,13 +39,6 @@
 class Geometry
 {
   public:
-    /*typedef struct sequence_tag
-    {
-        int frame_number, duration;
-    }
-    sequence_element;
-
-    std::vector< std::vector<sequence_element> > sequences;*/
     glm::dvec3 center;
     double radius, mass, restitution, friction;
 

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -53,7 +53,7 @@ static size_t rand_bytes(uint8_t *buf, size_t buf_sz)
     return i;
 }
 
-base_user::base_user(uint64_t userid)
+base_user::base_user(userid_t userid)
     : username(), charactername(), Control(userid, NULL)
 {
     this->parent = NULL;
@@ -72,7 +72,7 @@ void base_user::prep_iv(void)
     rand_bytes(this->iv, R9_SYMMETRIC_IV_BUF_SZ);
 }
 
-base_user::base_user(uint64_t userid,
+base_user::base_user(userid_t userid,
                      const std::string& uname,
                      const std::string& cname,
                      listen_socket *l)
@@ -416,7 +416,7 @@ void listen_socket::login_user(access_list& p)
     std::string username(p.buf.log.username,
                          std::min(sizeof(p.buf.log.username),
                                   strlen(p.buf.log.username)));
-    uint64_t userid = database->check_authentication(username,
+    userid_t userid = database->check_authentication(username,
                                                      p.buf.log.pubkey,
                                                      R9_PUBKEY_SZ);
     if (userid == 0LL)
@@ -451,7 +451,7 @@ void listen_socket::login_user(access_list& p)
     zone->send_nearby_objects(bu->characterid);
 }
 
-void listen_socket::logout_user(uint64_t userid)
+void listen_socket::logout_user(userid_t userid)
 {
     packet_list pkt;
     listen_socket::users_iterator found;

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -89,7 +89,7 @@ base_user::base_user(userid_t userid,
         throw std::runtime_error("unauthorized user");
     if (this->auth_level >= ACCESS_MOVE)
     {
-        uint64_t objid = database->get_character_objectid(userid, cname);
+        objid_t objid = database->get_character_objectid(userid, cname);
         this->default_slave = this->slave = zone->find_game_object(objid);
         this->slave->connect(this);
     }
@@ -119,9 +119,9 @@ const base_user& base_user::operator=(const base_user& u)
 std::string base_user::to_string(void)
 {
     std::ostringstream s;
-    uint64_t obj_id = (this->default_slave != NULL
-                       ? this->default_slave->get_object_id()
-                       : 0LL);
+    objid_t obj_id = (this->default_slave != NULL
+                      ? this->default_slave->get_object_id()
+                      : 0LL);
 
     s << this->username
       << " (" << this->userid
@@ -474,7 +474,7 @@ void listen_socket::logout_user(userid_t userid)
 
 void listen_socket::connect_user(base_user *bu, access_list& al)
 {
-    uint64_t obj_id = 0LL;
+    objid_t obj_id = 0LL;
 
     this->users[bu->userid] = bu;
     if (bu->default_slave != NULL)

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -120,7 +120,7 @@ std::string base_user::to_string(void)
 {
     std::ostringstream s;
     objid_t obj_id = (this->default_slave != NULL
-                      ? this->default_slave->get_object_id()
+                      ? this->default_slave->object_id
                       : 0LL);
 
     s << this->username
@@ -480,7 +480,7 @@ void listen_socket::connect_user(base_user *bu, access_list& al)
     if (bu->default_slave != NULL)
     {
         bu->default_slave->activate();
-        obj_id = bu->default_slave->get_object_id();
+        obj_id = bu->default_slave->object_id;
     }
     bu->send_server_key(config.key.pub_key, R9_PUBKEY_SZ);
     bu->send_ack(TYPE_LOGREQ, bu->auth_level, obj_id);

--- a/server/classes/listensock.h
+++ b/server/classes/listensock.h
@@ -54,11 +54,11 @@ class base_user : public Control {
   protected:
     listen_socket *parent;
 
-    base_user(uint64_t);
+    base_user(userid_t);
     void prep_iv(void);
 
   public:
-    base_user(uint64_t,
+    base_user(userid_t,
               const std::string&,
               const std::string&,
               listen_socket *);
@@ -104,7 +104,7 @@ typedef struct access_list_tag
         login;
         struct
         {
-            uint64_t who;
+            userid_t who;
         }
         logout;
     }
@@ -119,7 +119,7 @@ class listen_socket : public basesock
     static const int PING_TIMEOUT = 30;
     static const int LINK_DEAD_TIMEOUT = 75;
 
-    typedef std::map<uint64_t, base_user *>::iterator users_iterator;
+    typedef std::map<userid_t, base_user *>::iterator users_iterator;
 
     typedef void (*packet_handler)(listen_socket *, packet&,
                                    base_user *, void *);
@@ -130,7 +130,7 @@ class listen_socket : public basesock
     std::thread reaper_thread;
 
     std::shared_mutex user_mutex;
-    std::map<uint64_t, base_user *> users;
+    std::map<userid_t, base_user *> users;
 
     ThreadPool<packet_list> *send_pool;
     ThreadPool<access_list> *access_pool;
@@ -153,7 +153,7 @@ class listen_socket : public basesock
     static void handle_logout(listen_socket *, packet&, base_user *, void *);
 
     void login_user(access_list&);
-    void logout_user(uint64_t);
+    void logout_user(userid_t);
 
     virtual void connect_user(base_user *, access_list&);
     virtual void disconnect_user(base_user *);

--- a/server/classes/listensock.h
+++ b/server/classes/listensock.h
@@ -43,7 +43,8 @@ class listen_socket;
 class base_user : public Control {
   public:
     std::string username, charactername;
-    uint64_t sequence, characterid;
+    uint64_t sequence;
+    charid_t characterid;
     time_t timestamp;
     bool pending_logout;
     uint8_t auth_level;

--- a/server/classes/modules/Makefile.am
+++ b/server/classes/modules/Makefile.am
@@ -21,11 +21,11 @@ serverlib_LTLIBRARIES = $(modules_libs)
 
 AM_LDFLAGS = -module -avoid-version
 
-libr9_MySQL_la_SOURCES = db.cc r9mysql.cc db.h
+libr9_MySQL_la_SOURCES = db.cc r9mysql.cc r9mysql.h db.h
 libr9_MySQL_la_CXXFLAGS= $(MYSQL_INCLUDES)
 libr9_MySQL_la_LIBADD = $(MYSQL_LDLIBS)
 
-libr9_pgsql_la_SOURCES = db.cc r9pgsql.cc db.h
+libr9_pgsql_la_SOURCES = db.cc r9pgsql.cc r9pgsql.h db.h
 libr9_pgsql_la_CXXFLAGS = $(PGSQL_INCLUDES)
 libr9_pgsql_la_LIBADD = $(PGSQL_LDLIBS)
 

--- a/server/classes/modules/db.h
+++ b/server/classes/modules/db.h
@@ -69,13 +69,13 @@ class DB
     virtual ~DB();
 
     /* Player functions */
-    virtual uint64_t check_authentication(const std::string&,
+    virtual userid_t check_authentication(const std::string&,
                                           const uint8_t *, size_t) = 0;
-    virtual int check_authorization(uint64_t, uint64_t) = 0;
-    virtual int check_authorization(uint64_t, const std::string&) = 0;
-    virtual uint64_t get_characterid(uint64_t, const std::string&) = 0;
-    virtual uint64_t get_character_objectid(uint64_t, const std::string&) = 0;
-    virtual int get_player_server_skills(uint64_t, uint64_t,
+    virtual int check_authorization(userid_t, uint64_t) = 0;
+    virtual int check_authorization(userid_t, const std::string&) = 0;
+    virtual uint64_t get_characterid(userid_t, const std::string&) = 0;
+    virtual uint64_t get_character_objectid(userid_t, const std::string&) = 0;
+    virtual int get_player_server_skills(userid_t, uint64_t,
                                          Control::skills_map&) = 0;
 
     /* Server functions */

--- a/server/classes/modules/db.h
+++ b/server/classes/modules/db.h
@@ -71,11 +71,11 @@ class DB
     /* Player functions */
     virtual userid_t check_authentication(const std::string&,
                                           const uint8_t *, size_t) = 0;
-    virtual int check_authorization(userid_t, uint64_t) = 0;
+    virtual int check_authorization(userid_t, charid_t) = 0;
     virtual int check_authorization(userid_t, const std::string&) = 0;
-    virtual uint64_t get_characterid(userid_t, const std::string&) = 0;
+    virtual charid_t get_characterid(userid_t, const std::string&) = 0;
     virtual uint64_t get_character_objectid(userid_t, const std::string&) = 0;
-    virtual int get_player_server_skills(userid_t, uint64_t,
+    virtual int get_player_server_skills(userid_t, charid_t,
                                          Control::skills_map&) = 0;
 
     /* Server functions */

--- a/server/classes/modules/db.h
+++ b/server/classes/modules/db.h
@@ -74,7 +74,7 @@ class DB
     virtual int check_authorization(userid_t, charid_t) = 0;
     virtual int check_authorization(userid_t, const std::string&) = 0;
     virtual charid_t get_characterid(userid_t, const std::string&) = 0;
-    virtual uint64_t get_character_objectid(userid_t, const std::string&) = 0;
+    virtual objid_t get_character_objectid(userid_t, const std::string&) = 0;
     virtual int get_player_server_skills(userid_t, charid_t,
                                          Control::skills_map&) = 0;
 

--- a/server/classes/modules/db.h
+++ b/server/classes/modules/db.h
@@ -39,6 +39,7 @@
 #ifndef __INC_DB_H__
 #define __INC_DB_H__
 
+#include <cstdint>
 #include <string>
 #include <map>
 

--- a/server/classes/modules/r9mysql.cc
+++ b/server/classes/modules/r9mysql.cc
@@ -135,7 +135,7 @@ MySQL::~MySQL()
 }
 
 /* Check that the user really is who they say they are */
-uint64_t MySQL::check_authentication(const std::string& user,
+userid_t MySQL::check_authentication(const std::string& user,
                                      const uint8_t *pubkey,
                                      size_t key_size)
 {
@@ -144,7 +144,7 @@ uint64_t MySQL::check_authentication(const std::string& user,
     MYSQL_BIND bind[2];
     unsigned long length[2];
     my_bool is_null, error;
-    uint64_t retval = 0;
+    userid_t retval = 0;
 
     db_handle = this->db_connect();
     stmt = mysql_stmt_init(db_handle);
@@ -184,7 +184,7 @@ uint64_t MySQL::check_authentication(const std::string& user,
 }
 
 /* See what kind of access the user/character is allowed on this server */
-int MySQL::check_authorization(uint64_t userid, uint64_t charid)
+int MySQL::check_authorization(userid_t userid, uint64_t charid)
 {
     MYSQL *db_handle;
     MYSQL_STMT *stmt;
@@ -229,7 +229,7 @@ int MySQL::check_authorization(uint64_t userid, uint64_t charid)
     return (int)retval;
 }
 
-int MySQL::check_authorization(uint64_t userid, const std::string& charname)
+int MySQL::check_authorization(userid_t userid, const std::string& charname)
 {
     MYSQL *db_handle;
     MYSQL_STMT *stmt;
@@ -276,7 +276,7 @@ int MySQL::check_authorization(uint64_t userid, const std::string& charname)
     return (int)retval;
 }
 
-uint64_t MySQL::get_characterid(uint64_t userid, const std::string& charname)
+uint64_t MySQL::get_characterid(userid_t userid, const std::string& charname)
 {
     MYSQL *db_handle;
     MYSQL_STMT *stmt;
@@ -319,7 +319,7 @@ uint64_t MySQL::get_characterid(uint64_t userid, const std::string& charname)
     return retval;
 }
 
-uint64_t MySQL::get_character_objectid(uint64_t userid,
+uint64_t MySQL::get_character_objectid(userid_t userid,
                                        const std::string& charname)
 {
     MYSQL *db_handle;
@@ -514,7 +514,7 @@ int MySQL::get_server_objects(GameObject::objects_map& gomap)
 }
 
 /* Get the list of a player's skills which are valid on this server */
-int MySQL::get_player_server_skills(uint64_t userid,
+int MySQL::get_player_server_skills(userid_t userid,
                                     uint64_t charid,
                                     Control::skills_map& actions)
 {

--- a/server/classes/modules/r9mysql.cc
+++ b/server/classes/modules/r9mysql.cc
@@ -319,15 +319,15 @@ charid_t MySQL::get_characterid(userid_t userid, const std::string& charname)
     return retval;
 }
 
-uint64_t MySQL::get_character_objectid(userid_t userid,
-                                       const std::string& charname)
+objid_t MySQL::get_character_objectid(userid_t userid,
+                                      const std::string& charname)
 {
     MYSQL *db_handle;
     MYSQL_STMT *stmt;
     MYSQL_BIND bind[3];
     unsigned long length;
     my_bool is_null, error;
-    uint64_t retval = 0;
+    objid_t retval = 0;
 
     db_handle = this->db_connect();
     stmt = mysql_stmt_init(db_handle);
@@ -444,7 +444,7 @@ int MySQL::get_server_objects(GameObject::objects_map& gomap)
     MYSQL *db_handle;
     MYSQL_STMT *stmt;
     MYSQL_BIND bind[5];
-    uint64_t objid;
+    objid_t objid;
     charid_t charid;
     long pos_x, pos_y, pos_z;
     unsigned long length[5];

--- a/server/classes/modules/r9mysql.cc
+++ b/server/classes/modules/r9mysql.cc
@@ -184,7 +184,7 @@ userid_t MySQL::check_authentication(const std::string& user,
 }
 
 /* See what kind of access the user/character is allowed on this server */
-int MySQL::check_authorization(userid_t userid, uint64_t charid)
+int MySQL::check_authorization(userid_t userid, charid_t charid)
 {
     MYSQL *db_handle;
     MYSQL_STMT *stmt;
@@ -276,14 +276,14 @@ int MySQL::check_authorization(userid_t userid, const std::string& charname)
     return (int)retval;
 }
 
-uint64_t MySQL::get_characterid(userid_t userid, const std::string& charname)
+charid_t MySQL::get_characterid(userid_t userid, const std::string& charname)
 {
     MYSQL *db_handle;
     MYSQL_STMT *stmt;
     MYSQL_BIND bind[2];
     unsigned long length;
     my_bool is_null, error;
-    uint64_t retval = 0;
+    charid_t retval = 0;
 
     db_handle = this->db_connect();
     stmt = mysql_stmt_init(db_handle);
@@ -444,7 +444,8 @@ int MySQL::get_server_objects(GameObject::objects_map& gomap)
     MYSQL *db_handle;
     MYSQL_STMT *stmt;
     MYSQL_BIND bind[5];
-    uint64_t objid, charid;
+    uint64_t objid;
+    charid_t charid;
     long pos_x, pos_y, pos_z;
     unsigned long length[5];
     my_bool is_null[5], error[5];

--- a/server/classes/modules/r9mysql.h
+++ b/server/classes/modules/r9mysql.h
@@ -54,7 +54,7 @@ class MySQL : public DB
     int check_authorization(userid_t, charid_t);
     int check_authorization(userid_t, const std::string&);
     charid_t get_characterid(userid_t, const std::string&);
-    uint64_t get_character_objectid(userid_t, const std::string&);
+    objid_t get_character_objectid(userid_t, const std::string&);
     int get_player_server_skills(userid_t, charid_t, Control::skills_map&);
 
     /* Server functions */

--- a/server/classes/modules/r9mysql.h
+++ b/server/classes/modules/r9mysql.h
@@ -50,12 +50,12 @@ class MySQL : public DB
     ~MySQL();
 
     /* Player functions */
-    uint64_t check_authentication(const std::string&, const uint8_t *, size_t);
-    int check_authorization(uint64_t, uint64_t);
-    int check_authorization(uint64_t, const std::string&);
-    uint64_t get_characterid(uint64_t, const std::string&);
-    uint64_t get_character_objectid(uint64_t, const std::string&);
-    int get_player_server_skills(uint64_t, uint64_t, Control::skills_map&);
+    userid_t check_authentication(const std::string&, const uint8_t *, size_t);
+    int check_authorization(userid_t, uint64_t);
+    int check_authorization(userid_t, const std::string&);
+    uint64_t get_characterid(userid_t, const std::string&);
+    uint64_t get_character_objectid(userid_t, const std::string&);
+    int get_player_server_skills(userid_t, uint64_t, Control::skills_map&);
 
     /* Server functions */
     int get_server_skills(actions_map&);

--- a/server/classes/modules/r9mysql.h
+++ b/server/classes/modules/r9mysql.h
@@ -29,9 +29,6 @@
 #define __INC_R9MYSQL_H__
 
 #include <mysql.h>
-
-#include <cstdint>
-
 #include "db.h"
 
 class MySQL : public DB

--- a/server/classes/modules/r9mysql.h
+++ b/server/classes/modules/r9mysql.h
@@ -51,11 +51,11 @@ class MySQL : public DB
 
     /* Player functions */
     userid_t check_authentication(const std::string&, const uint8_t *, size_t);
-    int check_authorization(userid_t, uint64_t);
+    int check_authorization(userid_t, charid_t);
     int check_authorization(userid_t, const std::string&);
-    uint64_t get_characterid(userid_t, const std::string&);
+    charid_t get_characterid(userid_t, const std::string&);
     uint64_t get_character_objectid(userid_t, const std::string&);
-    int get_player_server_skills(userid_t, uint64_t, Control::skills_map&);
+    int get_player_server_skills(userid_t, charid_t, Control::skills_map&);
 
     /* Server functions */
     int get_server_skills(actions_map&);

--- a/server/classes/modules/r9pgsql.cc
+++ b/server/classes/modules/r9pgsql.cc
@@ -115,7 +115,7 @@ PgSQL::~PgSQL()
 {
 }
 
-uint64_t PgSQL::check_authentication(const std::string& user,
+userid_t PgSQL::check_authentication(const std::string& user,
                                      const uint8_t *pubkey,
                                      size_t key_size)
 {
@@ -125,7 +125,7 @@ uint64_t PgSQL::check_authentication(const std::string& user,
     const int lens[2] = {static_cast<int>(user.size()),
                          static_cast<int>(key_size)};
     const int binary[2] = {0, 1};
-    uint64_t retval = 0;
+    userid_t retval = 0;
 
     res = PQexecParams(db_handle,
                        PgSQL::check_authentication_query,
@@ -138,7 +138,7 @@ uint64_t PgSQL::check_authentication(const std::string& user,
     return retval;
 }
 
-int PgSQL::check_authorization(uint64_t userid, uint64_t charid)
+int PgSQL::check_authorization(userid_t userid, uint64_t charid)
 {
     PGconn *db_handle = this->db_connect();
     PGresult *res;
@@ -159,7 +159,7 @@ int PgSQL::check_authorization(uint64_t userid, uint64_t charid)
     return retval;
 }
 
-int PgSQL::check_authorization(uint64_t userid, const std::string& charname)
+int PgSQL::check_authorization(userid_t userid, const std::string& charname)
 {
     PGconn *db_handle = this->db_connect();
     PGresult *res;
@@ -179,7 +179,7 @@ int PgSQL::check_authorization(uint64_t userid, const std::string& charname)
     return retval;
 }
 
-uint64_t PgSQL::get_characterid(uint64_t userid, const std::string& charname)
+uint64_t PgSQL::get_characterid(userid_t userid, const std::string& charname)
 {
     PGconn *db_handle = this->db_connect();
     PGresult *res;
@@ -198,7 +198,7 @@ uint64_t PgSQL::get_characterid(uint64_t userid, const std::string& charname)
     return retval;
 }
 
-uint64_t PgSQL::get_character_objectid(uint64_t userid,
+uint64_t PgSQL::get_character_objectid(userid_t userid,
                                        const std::string& charname)
 {
     PGconn *db_handle = this->db_connect();
@@ -286,8 +286,7 @@ int PgSQL::get_server_objects(GameObject::objects_map& gomap)
     return count;
 }
 
-int PgSQL::get_player_server_skills(uint64_t userid,
-                                    uint64_t charid,
+int PgSQL::get_player_server_skills(userid_t userid, uint64_t charid,
                                     Control::skills_map& actions)
 {
     PGconn *db_handle = this->db_connect();

--- a/server/classes/modules/r9pgsql.cc
+++ b/server/classes/modules/r9pgsql.cc
@@ -138,7 +138,7 @@ userid_t PgSQL::check_authentication(const std::string& user,
     return retval;
 }
 
-int PgSQL::check_authorization(userid_t userid, uint64_t charid)
+int PgSQL::check_authorization(userid_t userid, charid_t charid)
 {
     PGconn *db_handle = this->db_connect();
     PGresult *res;
@@ -179,13 +179,13 @@ int PgSQL::check_authorization(userid_t userid, const std::string& charname)
     return retval;
 }
 
-uint64_t PgSQL::get_characterid(userid_t userid, const std::string& charname)
+charid_t PgSQL::get_characterid(userid_t userid, const std::string& charname)
 {
     PGconn *db_handle = this->db_connect();
     PGresult *res;
     std::string user_id = std::to_string(userid);
     const char *vals[2] = {user_id.c_str(), charname.c_str()};
-    uint64_t retval = 0;
+    charid_t retval = 0;
 
     res = PQexecParams(db_handle,
                        PgSQL::get_characterid_query,
@@ -268,7 +268,7 @@ int PgSQL::get_server_objects(GameObject::objects_map& gomap)
         for (count = 0; count < num_tuples; ++count)
         {
             uint64_t objid = strtoull(PQgetvalue(res, count, 0), NULL, 10);
-            uint64_t charid = strtoull(PQgetvalue(res, count, 1), NULL, 10);
+            charid_t charid = strtoull(PQgetvalue(res, count, 1), NULL, 10);
 
             GameObject *go = new GameObject(NULL, NULL, objid);
             go->set_position(
@@ -286,7 +286,7 @@ int PgSQL::get_server_objects(GameObject::objects_map& gomap)
     return count;
 }
 
-int PgSQL::get_player_server_skills(userid_t userid, uint64_t charid,
+int PgSQL::get_player_server_skills(userid_t userid, charid_t charid,
                                     Control::skills_map& actions)
 {
     PGconn *db_handle = this->db_connect();

--- a/server/classes/modules/r9pgsql.cc
+++ b/server/classes/modules/r9pgsql.cc
@@ -198,15 +198,15 @@ charid_t PgSQL::get_characterid(userid_t userid, const std::string& charname)
     return retval;
 }
 
-uint64_t PgSQL::get_character_objectid(userid_t userid,
-                                       const std::string& charname)
+objid_t PgSQL::get_character_objectid(userid_t userid,
+                                      const std::string& charname)
 {
     PGconn *db_handle = this->db_connect();
     PGresult *res;
     std::string user_id = std::to_string(userid);
     std::string host_id = std::to_string(this->host_id);
     const char *vals[3] = {user_id.c_str(), charname.c_str(), host_id.c_str()};
-    uint64_t retval = 0;
+    objid_t retval = 0;
 
     res = PQexecParams(db_handle,
                        PgSQL::get_character_objectid_query,

--- a/server/classes/modules/r9pgsql.cc
+++ b/server/classes/modules/r9pgsql.cc
@@ -271,12 +271,11 @@ int PgSQL::get_server_objects(GameObject::objects_map& gomap)
             uint64_t charid = strtoull(PQgetvalue(res, count, 1), NULL, 10);
 
             GameObject *go = new GameObject(NULL, NULL, objid);
-            go->set_position(glm::dvec3(atol(PQgetvalue(res, count, 2))
-                                        / POSUPD_POS_SCALE,
-                                        atol(PQgetvalue(res, count, 3))
-                                        / POSUPD_POS_SCALE,
-                                        atol(PQgetvalue(res, count, 4))
-                                        / POSUPD_POS_SCALE));
+            go->set_position(
+                glm::dvec3(atol(PQgetvalue(res, count, 2)) / POSUPD_POS_SCALE,
+                           atol(PQgetvalue(res, count, 3)) / POSUPD_POS_SCALE,
+                           atol(PQgetvalue(res, count, 4)) / POSUPD_POS_SCALE)
+            );
             if (charid != 0LL)
                 go->deactivate();
             gomap[objid] = go;

--- a/server/classes/modules/r9pgsql.h
+++ b/server/classes/modules/r9pgsql.h
@@ -54,11 +54,11 @@ class PgSQL : public DB
 
     /* Player functions */
     userid_t check_authentication(const std::string&, const uint8_t *, size_t);
-    int check_authorization(userid_t, uint64_t);
+    int check_authorization(userid_t, charid_t);
     int check_authorization(userid_t, const std::string&);
-    uint64_t get_characterid(userid_t, const std::string&);
+    charid_t get_characterid(userid_t, const std::string&);
     uint64_t get_character_objectid(userid_t, const std::string&);
-    int get_player_server_skills(userid_t, uint64_t, Control::skills_map&);
+    int get_player_server_skills(userid_t, charid_t, Control::skills_map&);
 
     /* Server functions */
     int get_server_skills(actions_map&);

--- a/server/classes/modules/r9pgsql.h
+++ b/server/classes/modules/r9pgsql.h
@@ -53,12 +53,12 @@ class PgSQL : public DB
     ~PgSQL();
 
     /* Player functions */
-    uint64_t check_authentication(const std::string&, const uint8_t *, size_t);
-    int check_authorization(uint64_t, uint64_t);
-    int check_authorization(uint64_t, const std::string&);
-    uint64_t get_characterid(uint64_t, const std::string&);
-    uint64_t get_character_objectid(uint64_t, const std::string&);
-    int get_player_server_skills(uint64_t, uint64_t, Control::skills_map&);
+    userid_t check_authentication(const std::string&, const uint8_t *, size_t);
+    int check_authorization(userid_t, uint64_t);
+    int check_authorization(userid_t, const std::string&);
+    uint64_t get_characterid(userid_t, const std::string&);
+    uint64_t get_character_objectid(userid_t, const std::string&);
+    int get_player_server_skills(userid_t, uint64_t, Control::skills_map&);
 
     /* Server functions */
     int get_server_skills(actions_map&);

--- a/server/classes/modules/r9pgsql.h
+++ b/server/classes/modules/r9pgsql.h
@@ -57,7 +57,7 @@ class PgSQL : public DB
     int check_authorization(userid_t, charid_t);
     int check_authorization(userid_t, const std::string&);
     charid_t get_characterid(userid_t, const std::string&);
-    uint64_t get_character_objectid(userid_t, const std::string&);
+    objid_t get_character_objectid(userid_t, const std::string&);
     int get_player_server_skills(userid_t, charid_t, Control::skills_map&);
 
     /* Server functions */

--- a/server/classes/stream.h
+++ b/server/classes/stream.h
@@ -40,7 +40,7 @@ class stream_socket : public listen_socket
 {
   public:
     std::map<int, base_user *> fds;
-    std::map<uint64_t, int> user_fds;
+    std::map<userid_t, int> user_fds;
 
   protected:
     int max_fd;

--- a/server/classes/zone.cc
+++ b/server/classes/zone.cc
@@ -147,7 +147,7 @@ glm::ivec3 Zone::which_sector(const glm::dvec3& pos)
     return sector;
 }
 
-GameObject *Zone::find_game_object(uint64_t objid)
+GameObject *Zone::find_game_object(objid_t objid)
 {
     GameObject *go;
     GameObject::objects_iterator gi = this->game_objects.find(objid);
@@ -165,7 +165,7 @@ GameObject *Zone::find_game_object(uint64_t objid)
     return go;
 }
 
-void Zone::send_nearby_objects(uint64_t objid)
+void Zone::send_nearby_objects(objid_t objid)
 {
     GameObject *go = this->find_game_object(objid);
 

--- a/server/classes/zone.h
+++ b/server/classes/zone.h
@@ -69,8 +69,8 @@ class Zone
     Octree *sector_contains(const glm::dvec3&);
     glm::ivec3 which_sector(const glm::dvec3&);
 
-    GameObject *find_game_object(uint64_t);
-    virtual void send_nearby_objects(uint64_t);
+    GameObject *find_game_object(objid_t);
+    virtual void send_nearby_objects(objid_t);
 };
 
 #endif /* __INC_ZONE_H__ */

--- a/test/t_game_obj.cc
+++ b/test/t_game_obj.cc
@@ -12,7 +12,7 @@ void test_create_delete(void)
     Control *con = new Control(1LL, NULL);
 
     go = new GameObject(geom, con, 38LL);
-    is(go->get_object_id(), 38LL, test + "expected objectid");
+    is(go->object_id, 38LL, test + "expected objectid");
     is(go->master, con, test + "expected master");
     is(go->geometry, geom, test + "expected geometry");
 
@@ -21,7 +21,7 @@ void test_create_delete(void)
     geom = new Geometry();
     go = new GameObject(geom, con, 39LL);
     go->geometry = geom2;
-    is(go->get_object_id(), 39LL, test + "expected objectid");
+    is(go->object_id, 39LL, test + "expected objectid");
 
     delete go;
     delete con;
@@ -35,12 +35,12 @@ void test_clone(void)
     Control *con = new Control(1LL, NULL);
 
     go = new GameObject(geom, con, 45LL);
-    is(go->get_object_id(), 45LL, test + "expected objectid");
+    is(go->object_id, 45LL, test + "expected objectid");
     is(go->master, con, test + "expected master");
     is(go->geometry, geom, test + "expected geometry");
 
     GameObject *go2 = go->clone();
-    is(go2->get_object_id(), 45LL, test + "expected objectid");
+    is(go2->object_id, 45LL, test + "expected objectid");
     is(go2->master, con, test + "expected master");
     isnt(go2->geometry, geom, test + "expected geometry");
 
@@ -57,7 +57,7 @@ void test_connect_disconnect(void)
     Control *con = new Control(1LL, NULL);
 
     go = new GameObject(geom, con, 45LL);
-    is(go->get_object_id(), 45LL, test + "expected objectid");
+    is(go->object_id, 45LL, test + "expected objectid");
     is(go->master, con, test + "expected master");
     is(go->geometry, geom, test + "expected geometry");
 
@@ -113,7 +113,7 @@ void test_distance(void)
     Control *con = new Control(1LL, NULL);
 
     go = new GameObject(geom, con, 123LL);
-    is(go->get_object_id(), 123LL, test + "expected objectid");
+    is(go->object_id, 123LL, test + "expected objectid");
     is(go->master, con, test + "expected master");
     is(go->geometry, geom, test + "expected geometry");
 

--- a/test/t_game_obj.cc
+++ b/test/t_game_obj.cc
@@ -11,8 +11,6 @@ void test_create_delete(void)
     Geometry *geom = new Geometry(), *geom2 = new Geometry();
     Control *con = new Control(1LL, NULL);
 
-    GameObject::reset_max_id();
-
     go = new GameObject(geom, con, 38LL);
     is(go->get_object_id(), 38LL, test + "expected objectid");
     is(go->master, con, test + "expected master");
@@ -21,7 +19,7 @@ void test_create_delete(void)
     delete go;
 
     geom = new Geometry();
-    go = new GameObject(geom, con);
+    go = new GameObject(geom, con, 39LL);
     go->geometry = geom2;
     is(go->get_object_id(), 39LL, test + "expected objectid");
 
@@ -36,15 +34,13 @@ void test_clone(void)
     Geometry *geom = new Geometry();
     Control *con = new Control(1LL, NULL);
 
-    GameObject::reset_max_id();
-
     go = new GameObject(geom, con, 45LL);
     is(go->get_object_id(), 45LL, test + "expected objectid");
     is(go->master, con, test + "expected master");
     is(go->geometry, geom, test + "expected geometry");
 
     GameObject *go2 = go->clone();
-    is(go2->get_object_id(), 46LL, test + "expected objectid");
+    is(go2->get_object_id(), 45LL, test + "expected objectid");
     is(go2->master, con, test + "expected master");
     isnt(go2->geometry, geom, test + "expected geometry");
 
@@ -59,8 +55,6 @@ void test_connect_disconnect(void)
     GameObject *go = NULL;
     Geometry *geom = new Geometry();
     Control *con = new Control(1LL, NULL);
-
-    GameObject::reset_max_id();
 
     go = new GameObject(geom, con, 45LL);
     is(go->get_object_id(), 45LL, test + "expected objectid");
@@ -106,36 +100,6 @@ void test_activate_deactivate(void)
 
     go->activate();
     is(go->natures.size(), 0, test + "expected activated natures size");
-
-    delete go;
-    delete con;
-}
-
-void test_reset_id(void)
-{
-    std::string test = "reset_max_id: ";
-    GameObject *go = NULL;
-    Geometry *geom = new Geometry();
-    Control *con = new Control(1LL, NULL);
-
-    go = new GameObject(geom, con, 123LL);
-    is(go->get_object_id(), 123LL, test + "expected objectid");
-    is(go->master, con, test + "expected master");
-    is(go->geometry, geom, test + "expected geometry");
-
-    delete go;
-
-    geom = new Geometry();
-    go = new GameObject(geom, con);
-    is(go->get_object_id(), 124LL, test + "expected objectid");
-
-    delete go;
-
-    GameObject::reset_max_id();
-
-    geom = new Geometry();
-    go = new GameObject(geom, con);
-    is(go->get_object_id(), 0LL, test + "expected objectid");
 
     delete go;
     delete con;
@@ -261,8 +225,6 @@ void test_update(void)
     Control *con = new Control(1LL, NULL);
     packet pkt;
 
-    GameObject::reset_max_id();
-
     go = new GameObject(geom, con, 46LL);
 
     st = "inactive: ";
@@ -287,13 +249,12 @@ void test_update(void)
 
 int main(int argc, char **argv)
 {
-    plan(46);
+    plan(41);
 
     test_create_delete();
     test_clone();
     test_connect_disconnect();
     test_activate_deactivate();
-    test_reset_id();
     test_distance();
     test_accessors();
     test_move_and_rotate();

--- a/test/t_listensock.cc
+++ b/test/t_listensock.cc
@@ -405,7 +405,7 @@ void test_listen_socket_handle_action(void)
     zone = new fake_Zone(1000, 1, database);
     fake_listen_socket *listen = new fake_listen_socket(addr);
     fake_base_user *bu = new fake_base_user(123LL);
-    GameObject *go = new GameObject(NULL, bu);
+    GameObject *go = new GameObject(NULL, bu, 1234LL);
 
     /* Creating an actual ActionPool will be prohibitive, since it
      * requires so many other objects to make it go.  All we need here


### PR DESCRIPTION
We currently use `uint64_t` for all of our various ID types.  That might not remain the same; UUIDs are starting to look more attractive, and they don't fit into a 64-bit type.

We'll make defines for user, character, and object ID types, and make the conversions where the individual types are used.  Once we decide to change a given type, we only have to change it in one place.  The database modules might need massaging for these particular changes, but that's a lot less than what's included here.

We also make the game object ID constant, and stop the auto-incrementing ID values.  The desire to make the ID constant has been commented in the header file for a long time, so since we were making other mods to the class, we'll do that now too.  We drop the accessor, since we're dealing with a constant, saving call overhead in a number of call sites; it's now just a pointer dereference.

We also get rid of some unused stuff in the game objects and clean up some formatting.