### PR TITLE
Use user object for socket nearby check

### DIFF
--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -92,6 +92,7 @@ base_user::base_user(userid_t userid,
         objid_t objid = database->get_character_objectid(userid, cname);
         this->default_slave = this->slave = zone->find_game_object(objid);
         this->slave->connect(this);
+        zone->send_nearby_objects(objid);
     }
     this->characterid = database->get_characterid(userid, cname);
     database->get_player_server_skills(this->userid,
@@ -448,7 +449,6 @@ void listen_socket::login_user(access_list& p)
 
     std::clog << "login for user " << bu->to_string() << std::endl;
     this->connect_user(bu, p);
-    zone->send_nearby_objects(bu->slave->object_id);
 }
 
 void listen_socket::logout_user(userid_t userid)

--- a/server/classes/listensock.cc
+++ b/server/classes/listensock.cc
@@ -448,7 +448,7 @@ void listen_socket::login_user(access_list& p)
 
     std::clog << "login for user " << bu->to_string() << std::endl;
     this->connect_user(bu, p);
-    zone->send_nearby_objects(bu->characterid);
+    zone->send_nearby_objects(bu->slave->object_id);
 }
 
 void listen_socket::logout_user(userid_t userid)

--- a/test/t_listensock.cc
+++ b/test/t_listensock.cc
@@ -12,20 +12,6 @@ using namespace TAP;
 #include "mock_server_globals.h"
 #include "mock_zone.h"
 
-int fake_server_objects(GameObject::objects_map& gom)
-{
-    glm::dvec3 pos(100.0, 100.0, 100.0);
-
-    gom[1234LL] = new GameObject(NULL, NULL, 1234LL);
-    gom[1234LL]->set_position(pos);
-
-    gom[1235LL] = new GameObject(NULL, NULL, 1235LL);
-    pos.x = 125.0;
-    gom[1235LL]->set_position(pos);
-
-    return 2;
-}
-
 class fake_listen_socket : public listen_socket
 {
   public:

--- a/test/t_listensock.cc
+++ b/test/t_listensock.cc
@@ -611,7 +611,7 @@ void test_listen_socket_login(void)
 
     listen->login_user(access);
 
-    is(send_nearby_objects_count, 1, test + "expected nearby objects call");
+    is(send_nearby_objects_count, 0, test + "expected nearby objects call");
     is(listen->users.size(), 1, test + "expected user list size");
     is(listen->users[123LL]->auth_level, ACCESS_VIEW,
        test + "expected auth level");


### PR DESCRIPTION
When a user logs in, we send them position updates for each "nearby" object.  The method takes an object ID, to figure which object we need to use for the "nearby" check.

The object ID is just a uint64_t.  The character ID is also just a uint64_t.  We've been passing the character ID instead of the object ID, which of course will give the wrong result.

Our test world has very few objects, and our test user shares the same object ID and character ID, so while this has been a legitimate bug, we've never actually seen the result.